### PR TITLE
Better check for localStorage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "countly-sdk-web",
   "version": "0.9.2",
   "description": "Countly Web SDK",
-  "main": "lib/countly.min.js",
+  "main": "lib/countly.js",
   "keywords": [
     "Countly",
     "Analytics",

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -839,6 +839,12 @@
 		// Check for native support
 		if (typeof localStorage !== "undefined") {
 			lsSupport = true;
+			try {
+			  localStorage.setItem('testLocal', true);
+			} catch (e){
+			  lsSupport = false;
+			}
+			
 		}
 		
 		// If value is detected, set new or modify store


### PR DESCRIPTION
In Safari private browsing localStorage is defined but it is read only so I added a improved check for localStorage 