### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Countly web SDK is available on CDNJS. Use either
 
 or
 
-[https://cdn.jsdelivr.net/countly-sdk-web/latest/countly.min.js](https://cdn.jsdelivr.net/countly-sdk-web/latest/countly.min.js)
+[https://cdn.jsdelivr.net/npm/countly-sdk-web@latest/lib/countly.min.js](https://cdn.jsdelivr.net/npm/countly-sdk-web@latest/lib/countly.min.js)
 
 ## How to use Countly Web SDK?
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/countly-sdk-web.

Feel free to ping me if you have any questions regarding this change.