### PR TITLE
Fix issue when using  the same Countly instance across multiple JS contexts

### DIFF
--- a/lib/countly.js
+++ b/lib/countly.js
@@ -174,10 +174,10 @@
             Countly.onload = Countly.onload || [];
             Countly.ignore_visitor = getConfig("ignore_visitor", ob, false);
             Countly.require_consent = getConfig("require_consent", ob, false);
-            if (ob.ignore_referrers && Array.isArray( ob.ignore_referrers.constructor ) ) {
+            if (ob.ignore_referrers && Array.isArray( ob.ignore_referrers ) ) {
                 ignoreReferrers = ob.ignore_referrers;
             }
-            else if (Countly.ignore_referrers && Array.isArray( Countly.ignore_referrers.constructor ) ) {
+            else if (Countly.ignore_referrers && Array.isArray( Countly.ignore_referrers ) ) {
                 ignoreReferrers = Countly.ignore_referrers;
             }
 
@@ -292,7 +292,7 @@
                     if (typeof features[i] === "string") {
                         consents[i] = { features: [features[i]] };
                     }
-                    else if (features[i] && Array.isArray( features[i].constructor ) && features[i].length) {
+                    else if (features[i] && Array.isArray( features[i] ) && features[i].length) {
                         consents[i] = { features: features[i] };
                     }
                     else {
@@ -349,7 +349,7 @@
     */
     Countly.add_consent = function (feature) {
         log("Adding consent for " + feature);
-        if ( Array.isArray( feature.constructor ) ) {
+        if ( Array.isArray( feature ) ) {
             for (var i = 0; i < feature.length; i++) {
                 Countly.add_consent(feature[i]);
             }
@@ -397,7 +397,7 @@
     */
     Countly.remove_consent = function (feature) {
         log("Removing consent for " + feature);
-        if ( Array.isArray( feature.constructor ) ) {
+        if ( Array.isArray( feature ) ) {
             for (var i = 0; i < feature.length; i++) {
                 Countly.remove_consent(feature[i]);
             }
@@ -981,7 +981,7 @@
     Countly.track_pageview = function (page, ignoreList) {
         reportViewDuration();
         //we got ignoreList first
-        if (page && Array.isArray( page.constructor ) ) {
+        if (page && Array.isArray( page ) ) {
             ignoreList = page;
             page = null;
         }
@@ -1693,7 +1693,7 @@
                 if (typeof req === "function") {
                     req();
                 }
-                else if ( Array.isArray( req.constructor ) && req.length > 0) {
+                else if ( Array.isArray( req ) && req.length > 0) {
                     if (typeof Countly[req[0]] !== "undefined") {
                         Countly[req[0]].apply(null, req.slice(1));
                     }

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -174,10 +174,10 @@
             Countly.onload = Countly.onload || [];
             Countly.ignore_visitor = getConfig("ignore_visitor", ob, false);
             Countly.require_consent = getConfig("require_consent", ob, false);
-            if (ob.ignore_referrers && ob.ignore_referrers.constructor === Array) {
+            if (ob.ignore_referrers && Array.isArray( ob.ignore_referrers.constructor ) ) {
                 ignoreReferrers = ob.ignore_referrers;
             }
-            else if (Countly.ignore_referrers && Countly.ignore_referrers.constructor === Array) {
+            else if (Countly.ignore_referrers && Array.isArray( Countly.ignore_referrers.constructor ) ) {
                 ignoreReferrers = Countly.ignore_referrers;
             }
 
@@ -292,7 +292,7 @@
                     if (typeof features[i] === "string") {
                         consents[i] = { features: [features[i]] };
                     }
-                    else if (features[i] && features[i].constructor === Array && features[i].length) {
+                    else if (features[i] && Array.isArray( features[i].constructor ) && features[i].length) {
                         consents[i] = { features: features[i] };
                     }
                     else {
@@ -349,7 +349,7 @@
     */
     Countly.add_consent = function (feature) {
         log("Adding consent for " + feature);
-        if (feature.constructor === Array) {
+        if ( Array.isArray( feature.constructor ) ) {
             for (var i = 0; i < feature.length; i++) {
                 Countly.add_consent(feature[i]);
             }
@@ -397,7 +397,7 @@
     */
     Countly.remove_consent = function (feature) {
         log("Removing consent for " + feature);
-        if (feature.constructor === Array) {
+        if ( Array.isArray( feature.constructor ) ) {
             for (var i = 0; i < feature.length; i++) {
                 Countly.remove_consent(feature[i]);
             }
@@ -981,7 +981,7 @@
     Countly.track_pageview = function (page, ignoreList) {
         reportViewDuration();
         //we got ignoreList first
-        if (page && page.constructor === Array) {
+        if (page && Array.isArray( page.constructor ) ) {
             ignoreList = page;
             page = null;
         }
@@ -1693,7 +1693,7 @@
                 if (typeof req === "function") {
                     req();
                 }
-                else if (req.constructor === Array && req.length > 0) {
+                else if ( Array.isArray( req.constructor ) && req.length > 0) {
                     if (typeof Countly[req[0]] !== "undefined") {
                         Countly[req[0]].apply(null, req.slice(1));
                     }


### PR DESCRIPTION
Countly SDK use `=== Array` to detect if an object is an array.
This method work fine as long as we are *in the same JS context*.

When using the same Countly instance across multiple JS context, the Array object is different in each individual context, thus making the comparison `=== Array` invalid.

Exemple:
When writing Web extension the countly sdk will be instanciated in one Js context, the extension context, but can also used from other JS context (such as JS contexts of an extension popup).

In that case, adding an event from the JS context of the popup using:
`this.countlySdk.q.push(['add_event', { ... }]);` 
Will push to `q` an object where it's constructor will be the Array object as defined in the popup JS context which will *not* be the Array object as defined in the JS context where countly sdk was instanciated.

Because of that  test in countly.js:1696 will fail and event will never by fired.

This PR fix that by using the Array.isArray method

:)