### PR TITLE
Fixed issue-39 (site corrupted after inserting a feedback widget)

### DIFF
--- a/lib/countly.js
+++ b/lib/countly.js
@@ -1566,7 +1566,7 @@
         var enableWidgets = params.popups || params.widgets;
 
         if (enableWidgets.length > 0) {
-            document.body.innerHTML += '<div id="cfbg"></div>';
+            document.body.insertAdjacentHTML('beforeend', '<div id="cfbg"></div>');
 
             sendXmlHttpRequest(Countly.url + '/o/feedback/multiple-widgets-by-id', {widgets:JSON.stringify(enableWidgets)}, function(err, params, responseText){
                 if(err){


### PR DESCRIPTION
Changed `document.body.innerHTML += '...'` to `document.body.insertAdjacentHTML('beforeend', ...)`.

`document.body.innerHTML += '...'` re-parses the complete `body`, which creates new elements, leaving elements previously saved by some other script unusable.
