### PR TITLE
fix error when removing items from storage from a second tab

### DIFF
--- a/lib/countly.js
+++ b/lib/countly.js
@@ -2444,14 +2444,14 @@
         switch(key) {
         //queue of requests
         case Countly.namespace + "cly_queue":
-            requestQueue = Countly.deserialize(e.newValue || []);
+            requestQueue = Countly.deserialize(e.newValue || '[]');
             break;
             //queue of events
         case Countly.namespace + "cly_event":
-            eventQueue = Countly.deserialize(e.newValue || []);
+            eventQueue = Countly.deserialize(e.newValue || '[]');
             break;
         case Countly.namespace + "cly_remote_configs":
-            remoteConfigs = Countly.deserialize(e.newValue || {});
+            remoteConfigs = Countly.deserialize(e.newValue || '{}');
             break;
         case Countly.namespace + "cly_ignore":
             Countly.ignore_visitor = Countly.deserialize(e.newValue);

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -2444,14 +2444,14 @@
         switch(key) {
         //queue of requests
         case Countly.namespace + "cly_queue":
-            requestQueue = Countly.deserialize(e.newValue);
+            requestQueue = Countly.deserialize(e.newValue || []);
             break;
             //queue of events
         case Countly.namespace + "cly_event":
-            eventQueue = Countly.deserialize(e.newValue);
+            eventQueue = Countly.deserialize(e.newValue || []);
             break;
         case Countly.namespace + "cly_remote_configs":
-            remoteConfigs = Countly.deserialize(e.newValue);
+            remoteConfigs = Countly.deserialize(e.newValue || {});
             break;
         case Countly.namespace + "cly_ignore":
             Countly.ignore_visitor = Countly.deserialize(e.newValue);


### PR DESCRIPTION
Hey Countly Team, thanks for making this great product.

I have noticed a bug in my application with the Countly library, steps to reproduce:


# Description of Issue and Steps to Reproduce 

1. Have a website with Countly installed
1. Open the website in one tab
1. Open another tab with the same website
1. Open up the dev console in both tabs
1. Clear an item from `localStorage` on one of the tabs, like `localStorage.removeItem('cly_event')`
1. Notice an error pop up on the other tab `cannot read property 'length' of null`

# Root Cause of Issue

I traced this down to a [line in the Countly SDK](https://github.com/Countly/countly-sdk-web/blob/master/lib/countly.js#L570):

```js
if (eventQueue.length > 0) {
```

I noticed that [another section of the Countly SDK](https://github.com/Countly/countly-sdk-web/blob/master/lib/countly.js#L2441-L2465) listens to changes on `localStorage`, and tries to update them when they change:

```js
window.addEventListener('storage', function(e) {
    var key = e.key + "";
    
    switch(key) {
    //queue of requests
    case Countly.namespace + "cly_queue":
        requestQueue = Countly.deserialize(e.newValue);
        break;
    //queue of events
    case Countly.namespace + "cly_event":
        eventQueue = Countly.deserialize(e.newValue);
        break;
    case Countly.namespace + "cly_remote_configs":
        remoteConfigs = Countly.deserialize(e.newValue);
        break;
    case Countly.namespace + "cly_ignore":
        Countly.ignore_visitor = Countly.deserialize(e.newValue);
        break;
    case Countly.namespace + "cly_id":
        Countly.device_id = Countly.deserialize(e.newValue);
        break;
    default:
        // do nothing
    }
});
```

So, for example, if we call `localStorage.removeItem('cly_event')`, the above code will be run and the new value of `eventQueue` will be `null`.

Then, when `eventQueue.length` is called, an error will be thrown.

I discovered the issue when running Cypress tests. Cypress clears lots of state-ish things between tests, and sometimes it does that just after the application has loaded, causing this error.

From reading the code, it seems to me like you never really want these values to be `null`, even if they are `null` in `localStorage`. 

What do you think of this PR? Also, if this can be merged, how can I get the change into the minified file? Are there any tests you need written?

Thanks!