### PR TITLE
[SDK-545] Name change for deprecated calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - `report_feedback` needs 'star-rating' consent only
 - ! Minor breaking change ! 'change_id' will now not accept invalid device ID values. It will now reject null, undefined, values that are not of the type string and empty string values.
 - Increased the default max event batch size to 100.
+- !! Major breaking change !! Enabling offline mode or changing device ID without merging will now clear the current consent. Consent has to be given again after performing this action.
 - Automatic orientation tracking is now enabled by default. It can be turned off during init.
 - Device ID can now be changed when no consent is given
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@
     - `show_feedback_popup` needs 'star-rating' consent only
     - `initialize_feedback_popups` needs 'star-rating' consent only
     - `report_feedback` needs 'star-rating' consent only
-- ! Minor breaking change ! 'change_id' will now not accept invalid device ID values. It will now reject null, undefined, values that are not of the type string and empty string values.
-- Increased the default max event batch size to 100.
 - !! Major breaking change !! Enabling offline mode or changing device ID without merging will now clear the current consent. Consent has to be given again after performing this action.
+- ! Minor breaking change ! 'change_id' will now not accept invalid device ID values. It will now reject null, undefined, values that are not of the type string and empty string values.
+- Deprecating `report_feedback`, now it redirects to `recordRatingWidgetWithID`
+- Deprecating `show_feedback_popup`, now it redirects to `presentRatingWidgetWithID`
+- Deprecating `initialize_feedback_popups`, now it redirects to `initializeRatingWidgets`
+- Deprecating `enable_feedback`, now it redirects to `enableRatingWidgets`
+- Deprecating `report_conversion`, now it redirects to `recordDirectAttribution`
+- Increased the default max event batch size to 100.
 - Automatic orientation tracking is now enabled by default. It can be turned off during init.
 - Device ID can now be changed when no consent is given
 

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -1834,42 +1834,42 @@
         };
         /**
         * Provide information about user
-        * @param {Object} feedback - object with feedback properties
-        * @param {string} feedback.widget_id - id of the widget in the dashboard
-        * @param {boolean=} feedback.contactMe - did user give consent to contact him
-        * @param {string=} feedback.platform - user's platform (will be filled if not provided)
-        * @param {string=} feedback.app_version - app's app version (will be filled if not provided)
-        * @param {number} feedback.rating - user's rating from 1 to 5
-        * @param {string=} feedback.email - user's email
-        * @param {string=} feedback.comment - user's comment
+        * @param {Object} ratingWidget - object with rating widget properties
+        * @param {string} ratingWidget.widget_id - id of the widget in the dashboard
+        * @param {boolean=} ratingWidget.contactMe - did user give consent to contact him
+        * @param {string=} ratingWidget.platform - user's platform (will be filled if not provided)
+        * @param {string=} ratingWidget.app_version - app's app version (will be filled if not provided)
+        * @param {number} ratingWidget.rating - user's rating from 1 to 5
+        * @param {string=} ratingWidget.email - user's email
+        * @param {string=} ratingWidget.comment - user's comment
         * 
         * @deprecated use 'recordRatingWidgetWithID' in place of this call
         **/
-        this.report_feedback = function(feedback) {
+        this.report_feedback = function(ratingWidget) {
             log("report_feedback, Deprecated function call! Use 'recordRatingWidgetWithID' in place of this call. Call will be redirected now!");
-            this.recordRatingWidgetWithID(feedback);
+            this.recordRatingWidgetWithID(ratingWidget);
         };
         /**
         * Provide information about user
-        * @param {Object} feedback - object with feedback properties
-        * @param {string} feedback.widget_id - id of the widget in the dashboard
-        * @param {boolean=} feedback.contactMe - did user give consent to contact him
-        * @param {string=} feedback.platform - user's platform (will be filled if not provided)
-        * @param {string=} feedback.app_version - app's app version (will be filled if not provided)
-        * @param {number} feedback.rating - user's rating from 1 to 5
-        * @param {string=} feedback.email - user's email
-        * @param {string=} feedback.comment - user's comment
+        * @param {Object} ratingWidget - object with rating widget properties
+        * @param {string} ratingWidget.widget_id - id of the widget in the dashboard
+        * @param {boolean=} ratingWidget.contactMe - did user give consent to contact him
+        * @param {string=} ratingWidget.platform - user's platform (will be filled if not provided)
+        * @param {string=} ratingWidget.app_version - app's app version (will be filled if not provided)
+        * @param {number} ratingWidget.rating - user's rating from 1 to 5
+        * @param {string=} ratingWidget.email - user's email
+        * @param {string=} ratingWidget.comment - user's comment
         **/
-        this.recordRatingWidgetWithID = function(feedback) {
+        this.recordRatingWidgetWithID = function(ratingWidget) {
             if (!this.check_consent(featureEnums.STAR_RATING)) {
                 return;
             }
-            if (!feedback.widget_id) {
-                log("Feedback must contain widget_id property");
+            if (!ratingWidget.widget_id) {
+                log("Rating Widget must contain widget_id property");
                 return;
             }
-            if (!feedback.rating) {
-                log("Feedback must contain rating property");
+            if (!ratingWidget.rating) {
+                log("Rating Widget must contain rating property");
                 return;
             }
             var props = ["widget_id", "contactMe", "platform", "app_version", "rating", "email", "comment"];
@@ -1878,16 +1878,16 @@
                 count: 1,
                 segmentation: {}
             };
-            event.segmentation = getProperties(feedback, props);
+            event.segmentation = getProperties(ratingWidget, props);
             if (!event.segmentation.app_version) {
                 event.segmentation.app_version = this.metrics._app_version || this.app_version;
             }
-            log("Reporting feedback: ", event);
+            log("Reporting Rating Widget: ", event);
             this.add_cly_event(event);
         };
         /**
         * Show specific widget popup by the widget id
-        * @param {string} id - id value of related feedback widget, you can get this value by click "Copy ID" button in row menu at "Feedback widgets" screen
+        * @param {string} id - id value of related rating widget, you can get this value by click "Copy ID" button in row menu at "Feedback widgets" screen
         * 
         * @deprecated use 'presentRatingWidgetWithID' in place of this call
         */
@@ -1897,14 +1897,14 @@
         };
         /**
         * Show specific widget popup by the widget id
-        * @param {string} id - id value of related feedback widget, you can get this value by click "Copy ID" button in row menu at "Feedback widgets" screen
+        * @param {string} id - id value of related rating widget, you can get this value by click "Copy ID" button in row menu at "Feedback widgets" screen
         */
         this.presentRatingWidgetWithID = function(id) {
             if (!this.check_consent(featureEnums.STAR_RATING)) {
                 return;
             }
             if (offlineMode) {
-                log("Cannot show feedback popup in offline mode");
+                log("Cannot show ratingWidget popup in offline mode");
             }
             else {
                 sendXmlHttpRequest(this.url + '/o/feedback/widget', {widget_id: id}, function(err, params, responseText) {
@@ -1924,7 +1924,7 @@
         };
 
         /**
-        * Prepare widgets according current options
+        * Prepare rating widgets according current options
         * @param {array=} enableWidgets - widget ids array
         * 
         * @deprecated use 'initializeRatingWidgets' in place of this call
@@ -1997,7 +1997,7 @@
         };
 
         /**
-        * Show feedback popup by passed widget ids array
+        * Show rating widget popup by passed widget ids array
         * @param {object=} params - required - includes "popups" property as string array of widgets ("widgets" for old versions)
         * example params: {"popups":["5b21581b967c4850a7818617"]}
         * 
@@ -2008,7 +2008,7 @@
             this.enableRatingWidgets(params);
         };
         /**
-        * Show feedback popup by passed widget ids array
+        * Show rating widget popup by passed widget ids array
         * @param {object=} params - required - includes "popups" property as string array of widgets ("widgets" for old versions)
         * example params: {"popups":["5b21581b967c4850a7818617"]}
         **/
@@ -2017,7 +2017,7 @@
                 return;
             }
             if (offlineMode) {
-                log("Cannot enable feedback in offline mode");
+                log("Cannot enable rating widgets in offline mode");
             }
             else {
                 store('cly_fb_widgets', params.popups || params.widgets);

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -1924,7 +1924,7 @@
         };
 
         /**
-        * Prepare rating widgets according current options
+        * Prepare rating widgets according to the current options
         * @param {array=} enableWidgets - widget ids array
         * 
         * @deprecated use 'initializeRatingWidgets' in place of this call
@@ -1934,7 +1934,7 @@
             this.initializeRatingWidgets(enableWidgets);
         };
         /**
-        * Prepare widgets according current options
+        * Prepare rating widgets according to the current options
         * @param {array=} enableWidgets - widget ids array
         */
         this.initializeRatingWidgets = function(enableWidgets) {

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -434,22 +434,29 @@
         /**
         * Remove consent for specific feature, meaning, user opted out to track that data (either core feature of from custom feature group)
         * @param {string|array} feature - name of the feature, possible values, "sessions","events","views","scrolls","clicks","forms","crashes","attribution","users", etc or custom provided through {@link Countly.group_features}
+        * @param {Boolean} enforceConsentUpdate - regulates if a request will be sent to the server or not. If true, removing consents will send a request to the server and if false, consents will be removed without a request 
         */
         this.remove_consent = function(feature) {
             log("Removing consent for " + feature);
+            this.remove_consent_internal(feature, true);
+        };
+        //removes consent without updating
+        this.remove_consent_internal = function(feature, enforceConsentUpdate) {
+            //if true updateConsent will execute when possible
+            enforceConsentUpdate = enforceConsentUpdate || false;
             if (Array.isArray(feature)) {
                 for (var i = 0; i < feature.length; i++) {
-                    this.remove_consent(feature[i]);
+                    this.remove_consent_internal(feature[i], enforceConsentUpdate);
                 }
             }
             else if (consents[feature]) {
                 if (consents[feature].features) {
                     //this is added group, let's iterate through sub features
-                    this.remove_consent(consents[feature].features);
+                    this.remove_consent_internal(consents[feature].features, enforceConsentUpdate);
                 }
                 else {
                     //this is core feature
-                    if (consents[feature].optin !== false) {
+                    if (enforceConsentUpdate && consents[feature].optin !== false) {
                         syncConsents[feature] = false;
                         updateConsent();
                     }
@@ -479,6 +486,8 @@
         };
 
         this.enable_offline_mode = function() {
+            //clear consents
+            this.remove_consent_internal(Countly.features, false);
             offlineMode = true;
             this.device_id = "[CLY]_temp_id";
         };
@@ -605,6 +614,8 @@
                     this.end_session(null, true);
                     //clear timed events
                     timedEvents = {};
+                    //clear all consents
+                    this.remove_consent_internal(Countly.features, false);
                 }
                 var oldId = this.device_id;
                 this.device_id = newId;

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -735,8 +735,19 @@
         * Report user conversion to the server (when user signup or made a purchase, or whatever your conversion is), if there is no campaign data, user will be reported as organic
         * @param {string=} campaign_id - id of campaign, or will use the one that is stored after campaign link click
         * @param {string=} campaign_user_id - id of user's click on campaign, or will use the one that is stored after campaign link click
+        * 
+        * @deprecated use 'recordDirectAttribution' in place of this call
         **/
         this.report_conversion = function(campaign_id, campaign_user_id) {
+            log("report_conversion, Deprecated function call! Use 'recordDirectAttribution' in place of this call. Call will be redirected now!");
+            this.recordDirectAttribution(campaign_id, campaign_user_id);
+        };
+        /**
+        * Report user conversion to the server (when user signup or made a purchase, or whatever your conversion is), if there is no campaign data, user will be reported as organic
+        * @param {string=} campaign_id - id of campaign, or will use the one that is stored after campaign link click
+        * @param {string=} campaign_user_id - id of user's click on campaign, or will use the one that is stored after campaign link click
+        **/
+        this.recordDirectAttribution = function(campaign_id, campaign_user_id) {
             if (this.check_consent("attribution")) {
                 campaign_id = campaign_id || store("cly_cmp_id") || "cly_organic";
                 campaign_user_id = campaign_user_id || store("cly_cmp_uid");
@@ -1757,7 +1768,23 @@
                 heartBeat();
             }
         };
-
+        /**
+        * Provide information about user
+        * @param {Object} feedback - object with feedback properties
+        * @param {string} feedback.widget_id - id of the widget in the dashboard
+        * @param {boolean=} feedback.contactMe - did user give consent to contact him
+        * @param {string=} feedback.platform - user's platform (will be filled if not provided)
+        * @param {string=} feedback.app_version - app's app version (will be filled if not provided)
+        * @param {number} feedback.rating - user's rating from 1 to 5
+        * @param {string=} feedback.email - user's email
+        * @param {string=} feedback.comment - user's comment
+        * 
+        * @deprecated use 'recordRatingWidgetWithID' in place of this call
+        **/
+        this.report_feedback = function(feedback) {
+            log("report_feedback, Deprecated function call! Use 'recordRatingWidgetWithID' in place of this call. Call will be redirected now!");
+            this.recordRatingWidgetWithID(feedback);
+        };
         /**
         * Provide information about user
         * @param {Object} feedback - object with feedback properties
@@ -1769,7 +1796,7 @@
         * @param {string=} feedback.email - user's email
         * @param {string=} feedback.comment - user's comment
         **/
-        this.report_feedback = function(feedback) {
+        this.recordRatingWidgetWithID = function(feedback) {
             if (!this.check_consent("star-rating")) {
                 return;
             }
@@ -1796,12 +1823,21 @@
                 this.add_event(event);
             }
         };
-
+        /**
+        * Show specific widget popup by the widget id
+        * @param {string} id - id value of related feedback widget, you can get this value by click "Copy ID" button in row menu at "Feedback widgets" screen
+        * 
+        * @deprecated use 'presentRatingWidgetWithID' in place of this call
+        */
+        this.show_feedback_popup = function(id) {
+            log("show_feedback_popup, Deprecated function call! Use 'presentRatingWidgetWithID' in place of this call. Call will be redirected now!");
+            this.presentRatingWidgetWithID(id);
+        };
         /**
         * Show specific widget popup by the widget id
         * @param {string} id - id value of related feedback widget, you can get this value by click "Copy ID" button in row menu at "Feedback widgets" screen
         */
-        this.show_feedback_popup = function(id) {
+        this.presentRatingWidgetWithID = function(id) {
             if (!this.check_consent("star-rating")) {
                 return;
             }
@@ -1828,8 +1864,18 @@
         /**
         * Prepare widgets according current options
         * @param {array=} enableWidgets - widget ids array
+        * 
+        * @deprecated use 'initializeRatingWidgets' in place of this call
         */
         this.initialize_feedback_popups = function(enableWidgets) {
+            log("initialize_feedback_popups, Deprecated function call! Use 'initializeRatingWidgets' in place of this call. Call will be redirected now!");
+            this.initializeRatingWidgets(enableWidgets);
+        };
+        /**
+        * Prepare widgets according current options
+        * @param {array=} enableWidgets - widget ids array
+        */
+        this.initializeRatingWidgets = function(enableWidgets) {
             if (!this.check_consent("star-rating")) {
                 return;
             }
@@ -1892,8 +1938,19 @@
         * Show feedback popup by passed widget ids array
         * @param {object=} params - required - includes "popups" property as string array of widgets ("widgets" for old versions)
         * example params: {"popups":["5b21581b967c4850a7818617"]}
+        * 
+        * @deprecated use 'enableRatingWidgets' in place of this call
         **/
         this.enable_feedback = function(params) {
+            log("enable_feedback, Deprecated function call! Use 'enableRatingWidgets' in place of this call. Call will be redirected now!");
+            this.enableRatingWidgets(params);
+        };
+        /**
+        * Show feedback popup by passed widget ids array
+        * @param {object=} params - required - includes "popups" property as string array of widgets ("widgets" for old versions)
+        * example params: {"popups":["5b21581b967c4850a7818617"]}
+        **/
+        this.enableRatingWidgets = function(params) {
             if (!this.check_consent("star-rating")) {
                 return;
             }
@@ -1910,7 +1967,7 @@
 
                 if (enableWidgets.length > 0) {
                     document.body.insertAdjacentHTML('beforeend', '<div id="cfbg"></div>');
-                    this.initialize_feedback_popups(enableWidgets);
+                    this.initializeRatingWidgets(enableWidgets);
                 }
                 else {
                     log("You should provide at least one widget id as param. Read documentation for more detail. https://resources.count.ly/plugins/feedback");

--- a/samples/react/src/Location-WithEffect.js
+++ b/samples/react/src/Location-WithEffect.js
@@ -13,7 +13,7 @@ const Location = (props) => {
     //Check if pathname is not changing dont track the view
     //So that you dont end up tracking the same view again and again
     Countly.q.push(['track_pageview', location.pathname]);
-    // Initialize feedback popup by current page/pathname
+    // Initialize rating widget popup by current page/pathname
     Countly.q.push(['initializeRatingWidgets']);
   }, [location]);
 

--- a/samples/react/src/Location-WithEffect.js
+++ b/samples/react/src/Location-WithEffect.js
@@ -14,7 +14,7 @@ const Location = (props) => {
     //So that you dont end up tracking the same view again and again
     Countly.q.push(['track_pageview', location.pathname]);
     // Initialize feedback popup by current page/pathname
-    Countly.q.push(['initialize_feedback_popups']);
+    Countly.q.push(['initializeRatingWidgets']);
   }, [location]);
 
   return (

--- a/samples/react/src/index.js
+++ b/samples/react/src/index.js
@@ -48,7 +48,7 @@ if (typeof(localStorage) !== "undefined") {
     }
 }
 
-Countly.q.push(['enable_feedback', {'widgets': ['widget-id-1','widget-id-2']}]);
+Countly.q.push(['enableRatingWidgets', {'widgets': ['widget-id-1','widget-id-2']}]);
 Countly.q.push(['track_sessions']);
 Countly.q.push(['track_scrolls']);
 Countly.q.push(['track_clicks']);


### PR DESCRIPTION
- Changed `report_feedback` to `recordRatingWidgetWithID`. Now old call redirects to the new one.
- Changed `show_feedback_popup` to `presentRatingWidgetWithID`. Now old call redirects to the new one.
- Changed `initialize_feedback_popups` to `initializeRatingWidgets`. Now old call redirects to the new one.
- Changed `enable_feedback` to `enableRatingWidgets`. Now old call redirects to the new one.
- Changed `report_conversion` to `recordDirectAttribution`. Now old call redirects to the new one.
- Fixed some places where deprecated call was used. Changed with new one.
- Added changelog entries