### PR TITLE
[SDK-364] Internal Limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
     - `report_feedback` needs 'star-rating' consent only
 - !! Major breaking change !! Enabling offline mode or changing device ID without merging will now clear the current consent. Consent has to be given again after performing this action.
 - ! Minor breaking change ! 'change_id' will now not accept invalid device ID values. It will now reject null, undefined, values that are not of the type string and empty string values.
+- Multiple values now have a default limit adjustable at initialization:
+    - Maximum size of all string keys is now 128 characters by default.
+    - Maximum size of all values in key-value pairs is now 256 characters by default.
+    - Maximum amount of segmentation in one event is mow 30 key-value pairs by default.
+    - Maximum amount of breadcrumbs that can be recorded at once is now 100 by default.
+    - Maximum stack trace lines per thread is now 30 by default.
+    - Maximum stack trace line length is now 200 by default. 
 - When recording internal events with 'add_event', the respective feature consent will now be checked instead of the 'events' consent. 
 - Increased the default max event batch size to 100.
 - Automatic orientation tracking is now enabled by default. It can be turned off during init.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 21.11
+## 21.11.0
 - !! Major breaking change !! Rating and Feedback widgets now require 'star-rating' or 'feedback' consent exclusively, according to their type, instead of both:
     - `present_feedback_widget` needs 'feedback' consent only
     - `get_available_feedback_widgets` needs 'feedback' consent only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
     - `report_feedback` needs 'star-rating' consent only
 - !! Major breaking change !! Enabling offline mode or changing device ID without merging will now clear the current consent. Consent has to be given again after performing this action.
 - ! Minor breaking change ! 'change_id' will now not accept invalid device ID values. It will now reject null, undefined, values that are not of the type string and empty string values.
-- Multiple values now have a default limit adjustable at initialization:
+- ! Minor breaking change ! Multiple values now have a default limit adjustable at initialization:
     - Maximum size of all string keys is now 128 characters by default.
     - Maximum size of all values in key-value pairs is now 256 characters by default.
     - Maximum amount of segmentation in one event is mow 30 key-value pairs by default.

--- a/examples/example_internal_limits.html
+++ b/examples/example_internal_limits.html
@@ -5,8 +5,8 @@
     <script type="text/javascript">
       //initializing Countly with params and passing require_consent config as true
       Countly.init({
-        app_key: "21cf5a730c3152bf1cb0d1ace048e25ac9d66b90",
-        url: "https://master.count.ly", //your server goes here
+        app_key: "YOUR_APP_KEY_HERE",
+        url: "https://try.count.ly", //your server goes here
         debug: true, //to read the logs
         max_key_length: 10, //set maximum key length here
         max_value_size: 6, //set maximum value length here

--- a/examples/example_internal_limits.html
+++ b/examples/example_internal_limits.html
@@ -8,12 +8,12 @@
         app_key: "YOUR_APP_KEY_HERE",
         url: "https://try.count.ly", //your server goes here
         debug: true, //to read the logs
-        max_key_length: 10, //set maximum key length here
-        max_value_size: 5, //set maximum value length here
+        max_key_length: 9, //set maximum key length here
+        max_value_size: 6, //set maximum value length here
         max_segmentation_values: 5, //set maximum segmentation number here
         max_breadcrumb_count: 5, //set maximum number of logs that will be stored before erasing old ones
         max_stack_trace_lines_per_thread: 5, //set maximum number of lines for stack trace
-        max_stack_trace_line_length: 5, //set maximum length of a line for stack trace
+        max_stack_trace_line_length: 10, //set maximum length of a line for stack trace
         require_consent: true, //this true means consent is required
       });
 
@@ -55,9 +55,9 @@
       }
       //then you can test stack trace related limits here (line length and line per line)
       function recordError() {
-        //create new error object with stack key
+        //create new error object with stack key (a lorem ipsum given as an example)
         var error = {
-          stack: "Enter your\n error here\n separated\n with newlines\n",
+          stack: "Lorem ipsum dolor sit amet,\n consectetur adipiscing elit, sed do eiusmod tempor\n incididunt ut labore et dolore magna\n aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n Duis aute irure dolor in reprehenderit in voluptate\n velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia\n deserunt mollit anim id\n est laborum.",
         };
         Countly.recordError(error, true);
       }
@@ -71,33 +71,41 @@
       //add user details
       function addUserDetails() {
         Countly.user_details({
-          name: "Arturs Sosins",
-          username: "ar2rsawseen",
+          name: "Osvaldo Genovesi",
+          username: "valdovaldo66",
           email: "test@test.com",
           organization: "Countly",
-          phone: "+37112345678",
+          phone: "+48117345679",
           //Web URL pointing to user picture
           picture:
-            "https://pbs.twimg.com/profile_images/1442562237/012_n_400x400.jpg",
+            "https://jooinn.com/images/sliced-apple-5.jpg",
           gender: "M",
-          byear: 1987, //birth year
+          byear: 1951, //birth year
           custom: {
-            key1: "value1",
-            key2: "value2",
+            "key1234567890": "Value100",
+            "key2345678901": "Value200",
+            "key3456789012": "Value300",
+            "key4567890123": "Value400",
+            "key5678901234": "Value500",
+            "key6789012345": "Value600",
+            "key7890123456": "Value700",
+            "key8901234567": "Value800",
+            "key9012345678": "Value900",
+            "key0123456789": "Value000",
           },
         });
       }
       //modify user data
       function set() {
-        Countly.userData.set("name", "Boba Fett"); //set custom property
+        Countly.userData.set("name of a character", "Boba Fett the second"); //set custom property
         Countly.userData.save();
       }
       function setOnce() {
-        Countly.userData.set_once("galaxy", "B48FF"); //set custom property only if property does not exist
+        Countly.userData.set_once("A galaxy far far away", "Called B48FF"); //set custom property only if property does not exist
         Countly.userData.save();
       }
       function incrementBig() {
-        Countly.userData.increment_by("byear", 10); //increment value in key by provided value
+        Countly.userData.increment_by("byear", 1234567890123456789); //increment value in key by provided value
         Countly.userData.save();
       }
       function increment() {
@@ -105,27 +113,27 @@
         Countly.userData.save();
       }
       function multiply() {
-        Countly.userData.multiply("byear", 2); //multiply value in key by provided value
+        Countly.userData.multiply("byear", 1234567890123456789); //multiply value in key by provided value
         Countly.userData.save();
       }
       function max() {
-        Countly.userData.max("byear", 1); //save max value between current and provided
+        Countly.userData.max("byear", 1234567890123456789); //save max value between current and provided
         Countly.userData.save();
       }
       function min() {
-        Countly.userData.min("byear", 5); //save min value between current and provided
+        Countly.userData.min("byear", 1234567890123456789); //save min value between current and provided
         Countly.userData.save();
       }
       function push() {
-        Countly.userData.push("gender", "F"); //add value to key as array element
+        Countly.userData.push("gender", "Fernando Valdez II"); //add value to key as array element
         Countly.userData.save();
       }
       function pushU() {
-        Countly.userData.push_unique("gender", "F"); //add value to key as array element, but only store unique values in array
+        Countly.userData.push_unique("gender", "Fernando Valdez III"); //add value to key as array element, but only store unique values in array
         Countly.userData.save();
       }
       function pull() {
-        Countly.userData.pull("gender", "F"); //remove value from array under property with key as name
+        Countly.userData.pull("gender",  "Fernando Valdez III"); //remove value from array under property with key as name
         Countly.userData.save();
       }
       //add custom event
@@ -134,8 +142,16 @@
           key: "Enter your key here",
           count: 1,
           segmentation: {
-            "key1": "Value1",
-            "key2 ": "Value2",
+            "key1234567890": "Value100",
+            "key2345678901": "Value200",
+            "key3456789012": "Value300",
+            "key4567890123": "Value400",
+            "key5678901234": "Value500",
+            "key6789012345": "Value600",
+            "key7890123456": "Value700",
+            "key8901234567": "Value800",
+            "key9012345678": "Value900",
+            "key0123456789": "Value000",
           },
         });
       }

--- a/examples/example_internal_limits.html
+++ b/examples/example_internal_limits.html
@@ -1,0 +1,78 @@
+<html>
+  <head>
+    <!--Countly script-->
+    <script type="text/javascript" src="../lib/countly.js"></script>
+    <script type="text/javascript">
+      //initializing Countly with params and passing require_consent config as true
+      Countly.init({
+        app_key: "21cf5a730c3152bf1cb0d1ace048e25ac9d66b90",
+        url: "https://master.count.ly", //your server goes here
+        debug: true, //to read the logs
+        max_key_length: 10, //set maximum key length here
+        max_value_size: 6, //set maximum value length here
+        max_segmentation_values: 4, //set maximum segmentation number here
+        max_breadcrumb_count: 1, //set maximum number of logs that will be stored before erasing old ones
+        max_stack_trace_lines_per_thread: 4, //set maximum number of lines for stack trace
+        max_stack_trace_line_length: 5, //set maximum length of a line for stack trace
+        require_consent: true, //this true means consent is required
+      });
+
+      //(optionally) provide custom feature tree if needed
+      Countly.group_features({
+        activity: ["sessions", "events", "views"],
+      });
+
+      //we can call all the helper methods we want, they won't record until consent is provided for specific features
+      Countly.track_sessions();
+      //we can check event key, value lengths and segmentation numbers with view event logs
+      Countly.track_pageview();
+
+
+      //Consent Management logic should be implemented and controlled by developer
+      //this is just a simply example of what logic it could have
+      if (typeof localStorage !== "undefined") {
+        var consents = localStorage.getItem("consents");
+        //checking if user already provided consent
+        if (consents) {
+          //we already have array with consents from previous visit, let's just pass them to Countly
+          Countly.add_consent(JSON.parse(consents));
+        } else {
+          //user have not yet provided us a consent
+          //we need to display popup and ask user to give consent for specific features we want to track
+          //for example purposes, we will wait till user clicks "Give Consent" button
+          //to allow consent for "activity", "crashes"
+        }
+      } else {
+        // Sorry! No Web Storage support..
+        // we can fallback to cookie
+      }
+
+      //first give consent for features to work
+      function giveConsent() {
+        //give consent to necessary features
+        var response = ["activity", "crashes"];
+        Countly.add_consent(response);
+        localStorage.setItem("consents", JSON.stringify(response));
+      }
+      //then you can test stack trace related limits here
+      function recordError() {
+        //create new error object with stack key
+        var error = {"stack":"Enter your\n error here\n separated\n with newlines\n"};
+        Countly.recordError(error, true);
+        
+      }
+      //you can add logs and check breadcrumb limits here
+      function addLog(){
+          //add new log into crashLogs
+          var log = "Enter your log here";
+          Countly.add_log(log);
+      }
+    </script>
+  </head>
+  <body>
+    <p><a href="http://count.ly/">Count.ly</a></p>
+    <p><button onclick="giveConsent()">Give Consent</button></p>
+    <p><button onclick="recordError()">Record Error</button></p>
+    <p><button onclick="addLog()">Add Log</button></p>
+  </body>
+</html>

--- a/examples/example_internal_limits.html
+++ b/examples/example_internal_limits.html
@@ -9,10 +9,10 @@
         url: "https://try.count.ly", //your server goes here
         debug: true, //to read the logs
         max_key_length: 10, //set maximum key length here
-        max_value_size: 6, //set maximum value length here
-        max_segmentation_values: 4, //set maximum segmentation number here
-        max_breadcrumb_count: 1, //set maximum number of logs that will be stored before erasing old ones
-        max_stack_trace_lines_per_thread: 4, //set maximum number of lines for stack trace
+        max_value_size: 5, //set maximum value length here
+        max_segmentation_values: 5, //set maximum segmentation number here
+        max_breadcrumb_count: 5, //set maximum number of logs that will be stored before erasing old ones
+        max_stack_trace_lines_per_thread: 5, //set maximum number of lines for stack trace
         max_stack_trace_line_length: 5, //set maximum length of a line for stack trace
         require_consent: true, //this true means consent is required
       });
@@ -24,9 +24,8 @@
 
       //we can call all the helper methods we want, they won't record until consent is provided for specific features
       Countly.track_sessions();
-      //we can check event key, value lengths and segmentation numbers with view event logs
+      //we can check event key, value lengths and segmentation numbers with view event logs here too
       Countly.track_pageview();
-
 
       //Consent Management logic should be implemented and controlled by developer
       //this is just a simply example of what logic it could have
@@ -50,29 +49,120 @@
       //first give consent for features to work
       function giveConsent() {
         //give consent to necessary features
-        var response = ["activity", "crashes"];
+        var response = ["activity", "crashes", "users"];
         Countly.add_consent(response);
         localStorage.setItem("consents", JSON.stringify(response));
       }
-      //then you can test stack trace related limits here
+      //then you can test stack trace related limits here (line length and line per line)
       function recordError() {
         //create new error object with stack key
-        var error = {"stack":"Enter your\n error here\n separated\n with newlines\n"};
+        var error = {
+          stack: "Enter your\n error here\n separated\n with newlines\n",
+        };
         Countly.recordError(error, true);
-        
       }
-      //you can add logs and check breadcrumb limits here
-      function addLog(){
-          //add new log into crashLogs
-          var log = "Enter your log here";
-          Countly.add_log(log);
+      //you can add logs and check breadcrumb limits here (present crashLogs limit at a time)
+      function addLog() {
+        //add new log into crashLogs
+        var log = "Enter your log here";
+        Countly.add_log(log);
+      }
+
+      //add user details
+      function addUserDetails() {
+        Countly.user_details({
+          name: "Arturs Sosins",
+          username: "ar2rsawseen",
+          email: "test@test.com",
+          organization: "Countly",
+          phone: "+37112345678",
+          //Web URL pointing to user picture
+          picture:
+            "https://pbs.twimg.com/profile_images/1442562237/012_n_400x400.jpg",
+          gender: "M",
+          byear: 1987, //birth year
+          custom: {
+            key1: "value1",
+            key2: "value2",
+          },
+        });
+      }
+      //modify user data
+      function set() {
+        Countly.userData.set("name", "Boba Fett"); //set custom property
+        Countly.userData.save();
+      }
+      function setOnce() {
+        Countly.userData.set_once("galaxy", "B48FF"); //set custom property only if property does not exist
+        Countly.userData.save();
+      }
+      function incrementBig() {
+        Countly.userData.increment_by("byear", 10); //increment value in key by provided value
+        Countly.userData.save();
+      }
+      function increment() {
+        Countly.userData.increment_by("byear"); //increment value in key by one
+        Countly.userData.save();
+      }
+      function multiply() {
+        Countly.userData.multiply("byear", 2); //multiply value in key by provided value
+        Countly.userData.save();
+      }
+      function max() {
+        Countly.userData.max("byear", 1); //save max value between current and provided
+        Countly.userData.save();
+      }
+      function min() {
+        Countly.userData.min("byear", 5); //save min value between current and provided
+        Countly.userData.save();
+      }
+      function push() {
+        Countly.userData.push("gender", "F"); //add value to key as array element
+        Countly.userData.save();
+      }
+      function pushU() {
+        Countly.userData.push_unique("gender", "F"); //add value to key as array element, but only store unique values in array
+        Countly.userData.save();
+      }
+      function pull() {
+        Countly.userData.pull("gender", "F"); //remove value from array under property with key as name
+        Countly.userData.save();
+      }
+      //add custom event
+      function add() {
+        Countly.add_event({
+          key: "Enter your key here",
+          count: 1,
+          segmentation: {
+            "key1": "Value1",
+            "key2 ": "Value2",
+          },
+        });
       }
     </script>
   </head>
   <body>
     <p><a href="http://count.ly/">Count.ly</a></p>
+    <h3>Give Consent First</h3>
+
     <p><button onclick="giveConsent()">Give Consent</button></p>
+    <h3>Check Stack Trace Limits</h3>
+
     <p><button onclick="recordError()">Record Error</button></p>
+    <h3>Check Breadcrumb Limits</h3>
     <p><button onclick="addLog()">Add Log</button></p>
+    <h3>Check Key/Value/Segmentation Limits</h3>
+    <p><button onclick="addUserDetails()">Add User Details</button></p>
+    <p><button onclick="set()">Set User Details</button></p>
+    <p><button onclick="setOnce()">Set Once User Details</button></p>
+    <p><button onclick="incrementBig()">Increment User Details</button></p>
+    <p><button onclick="increment()">Increment By One User Details</button></p>
+    <p><button onclick="multiply()">Multiply User Details</button></p>
+    <p><button onclick="max()">Max User Details</button></p>
+    <p><button onclick="min()">Min User Details</button></p>
+    <p><button onclick="push()">Push User Details</button></p>
+    <p><button onclick="pushU()">Push Unique User Details</button></p>
+    <p><button onclick="pull()">Pull User Details</button></p>
+    <p><button onclick="add()">Add Custom Event</button></p>
   </body>
 </html>

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -742,8 +742,10 @@
                 event.count = 1;
             }
             //truncate event name and segmentation to internal limits
-            event.key = truncateSingleValue(event.key, this.maxKeyLength, "add_cly_event");
-            event.segmentation = truncateObject(event.segmentation, this.maxKeyLength, this.maxValueSize, "add_cly_event");
+            log(event.key + " <- to trunk");
+            event.key = truncateSingleValue(event.key, self.maxKeyLength, "add_cly_event", self.debug);
+            log(event.key + " <- trunked?");
+            event.segmentation = truncateObject(event.segmentation, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "add_cly_event", self.debug);
             var props = ["key", "count", "sum", "dur", "segmentation"];
             var e = getProperties(event, props);
             e.timestamp = getMsTimestamp();
@@ -761,7 +763,7 @@
         **/
         this.start_event = function(key) {
             //truncate event name to internal limits
-            key = truncateSingleValue(key, this.maxKeyLength, "start_event");
+            key = truncateSingleValue(key, self.maxKeyLength, "start_event", this.debug);
             if (timedEvents[key]) {
                 log("Timed event with key " + key + " already started");
                 return;
@@ -841,15 +843,15 @@
             log("Adding user details: ", user);
             if (this.check_consent(featureEnums.USERS)) {
                 //truncating user values and custom object key value pairs
-                user.name = truncateSingleValue(user.name, this.maxValueSize, "user_details");
-                user.username = truncateSingleValue(user.username, this.maxValueSize, "user_details");
-                user.email = truncateSingleValue(user.email, this.maxValueSize, "user_details");
-                user.organization = truncateSingleValue(user.organization, this.maxValueSize, "user_details");
-                user.phone = truncateSingleValue(user.phone, this.maxValueSize, "user_details");
-                user.picture = truncateSingleValue(user.picture, 4096, "user_details");
-                user.gender = truncateSingleValue(user.gender, this.maxValueSize, "user_details");
-                user.byear = truncateSingleValue(user.byear, this.maxValueSize, "user_details");
-                user.custom = truncateObject(user.custom, this.maxKeyLength, this.maxValueSize, "user_details");
+                user.name = truncateSingleValue(user.name, self.maxValueSize, "user_details", this.debug);
+                user.username = truncateSingleValue(user.username, self.maxValueSize, "user_details", this.debug);
+                user.email = truncateSingleValue(user.email, self.maxValueSize, "user_details", this.debug);
+                user.organization = truncateSingleValue(user.organization, self.maxValueSize, "user_details", this.debug);
+                user.phone = truncateSingleValue(user.phone, self.maxValueSize, "user_details", this.debug);
+                user.picture = truncateSingleValue(user.picture, 4096, "user_details", this.debug);
+                user.gender = truncateSingleValue(user.gender, self.maxValueSize, "user_details", this.debug);
+                user.byear = truncateSingleValue(user.byear, self.maxValueSize, "user_details", this.debug);
+                user.custom = truncateObject(user.custom, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "user_details", this.debug);
                 var props = ["name", "username", "email", "organization", "phone", "picture", "gender", "byear", "custom"];
                 toRequestQueue({ user_details: JSON.stringify(getProperties(user, props)) });
             }
@@ -908,8 +910,8 @@
             **/
             set: function(key, value) {
                 //truncate user's custom property value to internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData set");
-                value = truncateSingleValue(value, this.maxValueSize, "userData set");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData set", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData set", this.debug);
                 customData[key] = value;
             },
             /**
@@ -928,8 +930,8 @@
             **/
             set_once: function(key, value) {
                 //truncate user's custom property value to internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData set_once");
-                value = truncateSingleValue(value, this.maxValueSize, "userData set_once");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData set_once", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData set_once", this.debug);
                 change_custom_property(key, value, "$setOnce");
             },
             /**
@@ -939,7 +941,7 @@
             **/
             increment: function(key) {
                 //truncate property name wrt internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData increment");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData increment", this.debug);
                 change_custom_property(key, 1, "$inc");
             },
             /**
@@ -950,8 +952,8 @@
             **/
             increment_by: function(key, value) {
                 //truncate property name and value wrt internal limits 
-                key = truncateSingleValue(key, this.maxKeyLength, "userData increment_by");
-                value = truncateSingleValue(value, this.maxValueSize, "userData increment_by");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData increment_by", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData increment_by", this.debug);
                 change_custom_property(key, value, "$inc");
             },
             /**
@@ -962,8 +964,8 @@
             **/
             multiply: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData multiply");
-                value = truncateSingleValue(value, this.maxValueSize, "userData multiply");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData multiply", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData multiply", this.debug);
                 change_custom_property(key, value, "$mul");
             },
             /**
@@ -974,8 +976,8 @@
             **/
             max: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData max");
-                value = truncateSingleValue(value, this.maxValueSize, "userData max");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData max", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData max", this.debug);
                 change_custom_property(key, value, "$max");
             },
             /**
@@ -986,8 +988,8 @@
             **/
             min: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData min");
-                value = truncateSingleValue(value, this.maxValueSize, "userData min");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData min", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData min", this.debug);
                 change_custom_property(key, value, "$min");
             },
             /**
@@ -998,8 +1000,8 @@
             **/
             push: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData push");
-                value = truncateSingleValue(value, this.maxValueSize, "userData push");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData push", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData push", this.debug);
                 change_custom_property(key, value, "$push");
             },
             /**
@@ -1010,8 +1012,8 @@
             **/
             push_unique: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, this.maxKeyLength, "userData push_unique");
-                value = truncateSingleValue(value, this.maxValueSize, "userData push_unique");
+                key = truncateSingleValue(key, self.maxKeyLength, "userData push_unique", this.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData push_unique", this.debug);
                 change_custom_property(key, value, "$addToSet");
             },
             /**
@@ -1055,8 +1057,8 @@
                     }
                 }
                 //truncate trace name and metrics wrt internal limits
-                trace.name = truncateSingleValue(trace.name, this.maxKeyLength, "report_trace");
-                trace.app_metrics = truncateObject(trace.app_metrics, this.maxKeyLength, this.maxValueSize, "report_trace");
+                trace.name = truncateSingleValue(trace.name, self.maxKeyLength, "report_trace", this.debug);
+                trace.app_metrics = truncateObject(trace.app_metrics, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "report_trace", this.debug);
                 var e = getProperties(trace, props);
                 e.timestamp = trace.stz;
                 var date = new Date();
@@ -1137,10 +1139,10 @@
         this.add_log = function(record) {
             if (this.check_consent(featureEnums.CRASHES)) {
                 //truncate description wrt internal limits
-                record = truncateSingleValue(record, this.maxValueSize, "add_log");
-                if (crashLogs.length > (this.maxBreadcrumbCount || maxCrashLogs || 100)) {
+                record = truncateSingleValue(record, self.maxValueSize, "add_log", this.debug);
+                if (crashLogs.length > (self.maxBreadcrumbCount || maxCrashLogs || 100)) {
                     crashLogs.shift();
-                    if (!this.maxBreadcrumbCount && maxCrashLogs) {
+                    if (!self.maxBreadcrumbCount && maxCrashLogs) {
                         log("'maxCrashLogs' is deprecated. Use 'maxBreadcrumbCount' instead!");
                     }
                 }
@@ -1350,8 +1352,8 @@
         this.track_pageview = function(page, ignoreList, viewSegments) {
             reportViewDuration();
             //truncate page name and segmentation wrt internal limits
-            page = truncateSingleValue(page, this.maxKeyLength, "track_pageview");
-            viewSegments = truncateObject(viewSegments, this.maxKeyLength, this.maxValueSize, "track_pageview");
+            page = truncateSingleValue(page, self.maxKeyLength, "track_pageview", this.debug);
+            viewSegments = truncateObject(viewSegments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "track_pageview", this.debug);
             //we got ignoreList first
             if (page && Array.isArray(page)) {
                 ignoreList = page;
@@ -1382,7 +1384,7 @@
                 "view": this.getViewUrl()
             };
             //truncate new segment
-            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize, "track_pageview");
+            segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "track_pageview", this.debug);
             if (this.track_domains) {
                 segments.domain = window.location.hostname;
             }
@@ -1474,7 +1476,7 @@
                                 "view": self.getViewUrl()
                             };
                             //truncate new segment
-                            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize, "processClick");
+                            segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "processClick", this.debug);
                             if (self.track_domains) {
                                 segments.domain = window.location.hostname;
                             }
@@ -1529,7 +1531,7 @@
                             "view": self.getViewUrl()
                         };
                         //truncate new segment
-                        segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize, "processScrollView");
+                        segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "processScrollView", this.debug);
                         if (self.track_domains) {
                             segments.domain = window.location.hostname;
                         }
@@ -2373,19 +2375,19 @@
                     error = err + "";
                 }
                 //truncate custom crash segment's key value pairs
-                segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
+                segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "record_error", this.debug);
                 //character limit check
-                if (error.length > (this.maxStackTraceLineLength * this.maxStackTraceLinesPerThread)) {
+                if (error.length > (self.maxStackTraceLineLength * self.maxStackTraceLinesPerThread)) {
                     //convert error into an array split from each newline 
                     var splittedError = error.split("\n");
                     //trim the array if it is too long
-                    if (splittedError.length > this.maxStackTraceLinesPerThread) {
-                        splittedError = splittedError.splice(0, this.maxStackTraceLinesPerThread);
+                    if (splittedError.length > self.maxStackTraceLinesPerThread) {
+                        splittedError = splittedError.splice(0, self.maxStackTraceLinesPerThread);
                     }
                     //trim each line to a given limit
-                    for (var i = 0, len = splittedError.length; i < len - 1; i++) {
-                        if (splittedError[i].length > this.maxStackTraceLineLength) {
-                            splittedError[i] = splittedError[i].substring(0, this.maxStackTraceLineLength);
+                    for (var i = 0, len = splittedError.length; i < len; i++) {
+                        if (splittedError[i].length > self.maxStackTraceLineLength) {
+                            splittedError[i] = splittedError[i].substring(0, self.maxStackTraceLineLength);
                         }
                     }
                     //turn modified array back into error string
@@ -3409,13 +3411,15 @@
      * @param {Object} obj - original object to be truncated
      * @param {Number} keyLimit - limit for key length
      * @param {Number} valueLimit - limit for value length
+     * @param {Number} segmentLimit - limit for segments pairs
      * @param {string} errorLog - prefix for error log
+     * @param {boolean} debugCondition - a boolean to indicate if debugging is enabled or not
      * @returns {Object} - the new truncated object
      */
-    function truncateObject(obj, keyLimit, valueLimit, errorLog) {
+    function truncateObject(obj, keyLimit, valueLimit, segmentLimit, errorLog, debugCondition) {
         var ob = {};
         if (obj) {
-            if (Object.keys(obj).length > this.maxSegmentationValues) {
+            if (Object.keys(obj).length > segmentLimit) {
                 var resizedObj = {};
                 for (var e in obj) {
                     resizedObj[e] = obj[e];
@@ -3428,20 +3432,29 @@
                 if (typeof key === 'string') {
                     if (key.length > keyLimit) {
                         newKey = key.substring(0, keyLimit);
-                        this.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
+                        if (debugCondition && typeof console !== "undefined") {
+                            // eslint-disable-next-line no-console
+                            console.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
+                        }
                     }
                 }
                 if (typeof obj[key] === 'string') {
                     if (obj[key].length > valueLimit) {
                         newValue = obj[key].substring(0, valueLimit);
-                        this.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
+                        if (debugCondition && typeof console !== "undefined") {
+                            // eslint-disable-next-line no-console
+                            console.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
+                        }
                     }
                 }
                 if (typeof key === 'number') {
                     newKey = newKey.toString();
                     if (newKey.length > keyLimit) {
                         newKey = parseInt(newKey.substring(0, keyLimit));
-                        this.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
+                        if (debugCondition && typeof console !== "undefined") {
+                            // eslint-disable-next-line no-console
+                            console.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
+                        }
                     }
                     else {
                         newKey = parseInt(newKey);
@@ -3451,7 +3464,10 @@
                     newValue = newValue.toString();
                     if (newValue.length > valueLimit) {
                         newValue = parseInt(newValue.substring(0, valueLimit));
-                        this.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
+                        if (debugCondition && typeof console !== "undefined") {
+                            // eslint-disable-next-line no-console
+                            console.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
+                        }
                     }
                     else {
                         newValue = parseInt(newValue);
@@ -3468,21 +3484,28 @@
      * @param {string|number} str - original value to be truncated
      * @param {Number} limit - limit length
      * @param {string} errorLog - prefix for error log
+     * @param {boolean} debugCondition - a boolean to indicate if debugging is enabled or not
      * @returns {string|number} - the new truncated value
      */
-    function truncateSingleValue(str, limit, errorLog) {
+    function truncateSingleValue(str, limit, errorLog, debugCondition) {
         var newStr = str;
         if (typeof str === 'string') {
             if (str.length > limit) {
                 newStr = str.substring(0, limit);
-                this.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
+                if (debugCondition && typeof console !== "undefined") {
+                    // eslint-disable-next-line no-console
+                    console.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
+                }
             }
         }
         else if (typeof str === 'number') {
             str = str.toString();
             if (str.length > limit) {
                 newStr = parseInt(str.substring(0, limit));
-                this.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
+                if (debugCondition && typeof console !== "undefined") {
+                    // eslint-disable-next-line no-console
+                    console.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
+                }
             }
             else {
                 newStr = parseInt(str);

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -172,7 +172,6 @@
             inactivityCounter = 0,
             sessionUpdate = getConfig("session_update", ob, 60),
             maxEventBatch = getConfig("max_events", ob, 100),
-            maxCrashLogs = getConfig("max_logs", ob, 100),
             useSessionCookie = getConfig("use_session_cookie", ob, true),
             sessionCookieTimeout = getConfig("session_cookie_timeout", ob, 30),
             readyToProcess = true,
@@ -185,22 +184,22 @@
             lsSupport = true,
             maxStackTraceThreadCount = 30,
             firstView = null;
-            
-            try {
-                localStorage.setItem("cly_testLocal", true);
-                //clean up test
-                localStorage.removeItem('cly_testLocal');
+
+        try {
+            localStorage.setItem("cly_testLocal", true);
+            //clean up test
+            localStorage.removeItem('cly_testLocal');
         }
         catch (e) {
             lsSupport = false;
         }
-        
+
         //create object to store consents
         var consents = {};
         for (var it = 0; it < Countly.features.length; it++) {
             consents[Countly.features[it]] = {};
         }
-        
+
         this.initialize = function() {
             this.serialize = ob.serialize || Countly.serialize;
             this.deserialize = ob.deserialize || Countly.deserialize;
@@ -233,9 +232,8 @@
             this.maxSegmentationValues = getConfig("max_segmentation_values", ob, 30),
             this.maxBreadcrumbCount = getConfig("max_breadcrumb_count", ob, 100),
             this.maxStackTraceLinesPerThread = getConfig("max_stack_trace_lines_per_thread", ob, 30),
-            this.maxStackTraceLineLength = getConfig("max_stack_trace_line_length", ob, 200),
-            
-            
+            this.maxStackTraceLineLength = getConfig("max_stack_trace_line_length", ob, 200);
+
             if (this.storage === "cookie") {
                 lsSupport = false;
             }
@@ -739,15 +737,11 @@
                 return;
             }
 
-            if (event.key.length > maxKeyLength) {
-                log("add_cly_events, Event key: " + event.key + " is longer than accepted length");
-                return;
-            }
-
             if (!event.count) {
                 event.count = 1;
             }
-
+            event.key = truncateSingleValue(event.key, this.maxKeyLength);
+            event.segmentation = truncateObject(event.segmentation, this.maxKeyLength, this.maxValueSize);
             var props = ["key", "count", "sum", "dur", "segmentation"];
             var e = getProperties(event, props);
             e.timestamp = getMsTimestamp();
@@ -764,10 +758,7 @@
         * @param {string} key - event name that will be used as key property
         **/
         this.start_event = function(key) {
-            if (key.length > maxKeyLength) {
-                log("start_event, Event key: " + key + " is longer than accepted length");
-                return;
-            }
+            key = truncateSingleValue(key, this.maxKeyLength);
             if (timedEvents[key]) {
                 log("Timed event with key " + key + " already started");
                 return;
@@ -844,6 +835,14 @@
         * @param {Object=} user.custom - object with custom key value properties you want to save with user
         **/
         this.user_details = function(user) {
+            user.name = truncateSingleValue(user.name, this.maxValueSize);
+            user.username = truncateSingleValue(user.username, this.maxValueSize);
+            user.email = truncateSingleValue(user.email, this.maxValueSize);
+            user.organization = truncateSingleValue(user.organization, this.maxValueSize);
+            user.phone = truncateSingleValue(user.phone, this.maxValueSize);
+            user.gender = truncateSingleValue(user.gender, this.maxValueSize);
+            user.byear = truncateSingleValue(user.byear, this.maxValueSize);
+            user.custom = truncateObject(user.custom, this.maxKeyLength, this.maxValueSize);
             if (this.check_consent(featureEnums.USERS)) {
                 log("Adding user details: ", user);
                 var props = ["name", "username", "email", "organization", "phone", "picture", "gender", "byear", "custom"];
@@ -903,6 +902,8 @@
             * @param {string|number} value - value to store under provided property
             **/
             set: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 customData[key] = value;
             },
             /**
@@ -920,6 +921,8 @@
             * @param {string|number} value - value to store under provided property
             **/
             set_once: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 change_custom_property(key, value, "$setOnce");
             },
             /**
@@ -928,6 +931,7 @@
             * @param {string} key - name of the property to attach to user
             **/
             increment: function(key) {
+                key = truncateSingleValue(key, this.maxKeyLength);
                 change_custom_property(key, 1, "$inc");
             },
             /**
@@ -937,6 +941,8 @@
             * @param {number} value - value by which to increment server value
             **/
             increment_by: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 change_custom_property(key, value, "$inc");
             },
             /**
@@ -946,6 +952,8 @@
             * @param {number} value - value by which to multiply server value
             **/
             multiply: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 change_custom_property(key, value, "$mul");
             },
             /**
@@ -955,6 +963,8 @@
             * @param {number} value - value which to compare to server's value and store maximal value of both provided
             **/
             max: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 change_custom_property(key, value, "$max");
             },
             /**
@@ -964,6 +974,8 @@
             * @param {number} value - value which to compare to server's value and store minimal value of both provided
             **/
             min: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 change_custom_property(key, value, "$min");
             },
             /**
@@ -973,6 +985,8 @@
             * @param {string|number} value - value which to add to array
             **/
             push: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 change_custom_property(key, value, "$push");
             },
             /**
@@ -982,6 +996,8 @@
             * @param {string|number} value - value which to add to array
             **/
             push_unique: function(key, value) {
+                key = truncateSingleValue(key, this.maxKeyLength);
+                value = truncateSingleValue(value, this.maxValueSize);
                 change_custom_property(key, value, "$addToSet");
             },
             /**
@@ -1024,10 +1040,8 @@
                         return;
                     }
                 }
-                if (trace.name.length > maxKeyLength) {
-                    log("report_trace, Trace name: " + trace.name + " is longer than accepted length");
-                    return;
-                }
+                trace.name = truncateSingleValue(trace.name, this.maxKeyLength);
+                trace.app_metrics = truncateObject(trace.app_metrics, this.maxKeyLength, this.maxValueSize);
                 var e = getProperties(trace, props);
                 e.timestamp = trace.stz;
                 var date = new Date();
@@ -1043,6 +1057,7 @@
         * @param {string=} segments - additional key value pairs you want to provide with error report, like versions of libraries used, etc.
         **/
         this.track_errors = function(segments) {
+            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
             Countly.i[this.app_key].tracking_crashes = true;
             if (!window.cly_crashes) {
                 window.cly_crashes = true;
@@ -1073,7 +1088,7 @@
                             var stack = [];
                             // eslint-disable-next-line no-caller
                             var f = arguments.callee.caller;
-                            while (f) {
+                            while (f && stack.length < maxStackTraceThreadCount) {
                                 stack.push(f.name);
                                 f = f.caller;
                             }
@@ -1106,8 +1121,9 @@
         * @param {string} record - any text describing what user did
         **/
         this.add_log = function(record) {
+            record = truncateSingleValue(record, this.maxValueSize);
             if (this.check_consent(featureEnums.CRASHES)) {
-                if (crashLogs.length > maxCrashLogs) {
+                if (crashLogs.length > this.maxBreadcrumbCount) {
                     crashLogs.shift();
                 }
                 crashLogs.push(record);
@@ -1315,10 +1331,8 @@
         **/
         this.track_pageview = function(page, ignoreList, viewSegments) {
             reportViewDuration();
-            if (page.length > maxKeyLength) {
-                log("track_pageview, Page name: " + page + " is longer than accepted length");
-                return;
-            }
+            page = truncateSingleValue(page, this.maxKeyLength);
+            viewSegments = truncateObject(viewSegments, this.maxKeyLength, this.maxValueSize);
             //we got ignoreList first
             if (page && Array.isArray(page)) {
                 ignoreList = page;
@@ -1348,7 +1362,7 @@
                 "visit": 1,
                 "view": this.getViewUrl()
             };
-
+            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
             if (this.track_domains) {
                 segments.domain = window.location.hostname;
             }
@@ -1439,6 +1453,7 @@
                                 "height": height,
                                 "view": self.getViewUrl()
                             };
+                            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
                             if (self.track_domains) {
                                 segments.domain = window.location.hostname;
                             }
@@ -1492,6 +1507,7 @@
                             "height": height,
                             "view": self.getViewUrl()
                         };
+                        segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
                         if (self.track_domains) {
                             segments.domain = window.location.hostname;
                         }
@@ -2308,6 +2324,7 @@
         this.recordError = function(err, nonfatal, segments) {
             if (this.check_consent(featureEnums.CRASHES) && err) {
                 segments = segments || crashSegments;
+                segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
                 var error = "";
                 if (typeof err === "object") {
                     if (typeof err.stack !== "undefined") {
@@ -2333,6 +2350,11 @@
                 }
                 else {
                     error = err + "";
+                }
+                var errorRegex = new RegExp("(?!$|\n)([^\n]{" + this.maxStackTraceLineLength + "}(?!\n))", "g");
+                error = error.replace(errorRegex, '$1\n');
+                if (error.split("\n").length > this.maxStackTraceLineLength) {
+                    error = error.split("\n").splice(0, this.maxStackTraceLinesPerThread).join("\n");
                 }
                 nonfatal = (nonfatal) ? true : false;
                 var metrics = getMetrics();
@@ -3145,7 +3167,6 @@
      * @param {number} [conf.inactivity_time=20] - after how many minutes user should be counted as inactive, if he did not perform any actions, as mouse move, scroll or keypress
      * @param {number} [conf.session_update=60] - how often in seconds should session be extended
      * @param {number} [conf.max_events=100] - maximum amount of events to send in one batch
-     * @param {number} [conf.max_logs=100] - maximum amount of breadcrumbs to store for crash logs
      * @param {number} [conf.max_key_length=128] - maximum size of all string keys
      * @param {number} [conf.max_value_size=256] - maximum size of all values in our key-value pairs (Except "picture" field, that has a limit of 4096 chars)
      * @param {number} [conf.max_max_segmentation_values=30] - max amount of custom (dev provided) segmentation in one event
@@ -3346,6 +3367,53 @@
     }
 
     /**
+     * Truncates an object's key/value pairs to a certain length
+     * @param {Object} obj - original object to be truncated
+     * @param {Number} keyLimit - limit for key length
+     * @param {Number} valueLimit - limit for value length
+     * @returns {Object} - the new truncated object
+     */
+    function truncateObject(obj, keyLimit, valueLimit) {
+        var ob = {};
+        if (Object.keys(obj).length > this.maxSegmentationValues) {
+            var resizedObj = {};
+            for (var e in obj) {
+                resizedObj[e] = obj[e];
+            }
+            obj = resizedObj;
+        }
+        for (var key in obj) {
+            var newKey = key;
+            var newValue = obj[key];
+            if (key.length > keyLimit) {
+                newKey = key.substring(0, keyLimit);
+                this.log("Key: " + key + " is longer than accepted length. It will be truncated.");
+            }
+            if (obj[key].length > valueLimit && (typeof obj[key] === 'string' || typeof obj[key] === 'number')) {
+                newValue = obj[key].substring(0, valueLimit);
+                this.log("Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
+            }
+            ob[newKey] = newValue;
+        }
+        return ob;
+    }
+
+    /**
+     * Truncates a single string to a certain length
+     * @param {string|number} str - original string to be truncated
+     * @param {Number} limit - limit length
+     * @returns {string|number} - the new truncated string
+     */
+    function truncateSingleValue(str, limit) {
+        var newStr = str;
+        if (str.length > limit && (typeof str === 'string' || typeof str === 'number')) {
+            newStr = str.substring(0, limit);
+            this.log("Key: " + str + " is longer than accepted length. It will be truncated.");
+        }
+        return newStr;
+    }
+
+    /**
      *  Polyfill to get closest parent matching nodeName
      *  @param {HTMLElementng} el - element from which to search
      *  @param {String} nodeName - tag/node name
@@ -3385,13 +3453,13 @@
      */
     var get_event_target = function(event) {
         if (!event) {
-            return window.event.srcElement;
+            return window.event.target;
         }
         else if (typeof event.target !== "undefined") {
             return event.target;
         }
         else {
-            return event.srcElement;
+            return event.target;
         }
     };
 

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -3169,10 +3169,10 @@
      * @param {number} [conf.max_events=100] - maximum amount of events to send in one batch
      * @param {number} [conf.max_key_length=128] - maximum size of all string keys
      * @param {number} [conf.max_value_size=256] - maximum size of all values in our key-value pairs (Except "picture" field, that has a limit of 4096 chars)
-     * @param {number} [conf.max_max_segmentation_values=30] - max amount of custom (dev provided) segmentation in one event
-     * @param {number} [conf.max_max_breadcrumb_count=100] - maximum amount of breadcrumbs that can be recorded before the oldest one is deleted
-     * @param {number} [conf.max_max_stack_trace_lines_per_thread=30] - maximum amount of stack trace lines would be recorded per thread
-     * @param {number} [conf.max_max_stack_trace_line_length=200] - maximum amount of characters are allowed per stack trace line. This limits also the crash message length
+     * @param {number} [conf.max_segmentation_values=30] - max amount of custom (dev provided) segmentation in one event
+     * @param {number} [conf.max_breadcrumb_count=100] - maximum amount of breadcrumbs that can be recorded before the oldest one is deleted
+     * @param {number} [conf.max_stack_trace_lines_per_thread=30] - maximum amount of stack trace lines would be recorded per thread
+     * @param {number} [conf.max_stack_trace_line_length=200] - maximum amount of characters are allowed per stack trace line. This limits also the crash message length
      * @param {array=} conf.ignore_referrers - array with referrers to ignore
      * @param {boolean} [conf.ignore_prefetch=true] - ignore prefetching and pre rendering from counting as real website visits
      * @param {boolean} [conf.force_post=false] - force using post method for all requests

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -172,7 +172,7 @@
             inactivityCounter = 0,
             sessionUpdate = getConfig("session_update", ob, 60),
             maxEventBatch = getConfig("max_events", ob, 100),
-            maxCrashLogs = getConfig("max_logs", ob, 100),
+            maxCrashLogs = getConfig("max_logs", ob, null),
             useSessionCookie = getConfig("use_session_cookie", ob, true),
             sessionCookieTimeout = getConfig("session_cookie_timeout", ob, 30),
             readyToProcess = true,
@@ -230,9 +230,17 @@
             this.maxKeyLength = getConfig("max_key_length", ob, 128),
             this.maxValueSize = getConfig("max_value_size", ob, 256),
             this.maxSegmentationValues = getConfig("max_segmentation_values", ob, 30),
-            this.maxBreadcrumbCount = getConfig("max_breadcrumb_count", ob, 100),
+            this.maxBreadcrumbCount = getConfig("max_breadcrumb_count", ob, null),
             this.maxStackTraceLinesPerThread = getConfig("max_stack_trace_lines_per_thread", ob, 30),
             this.maxStackTraceLineLength = getConfig("max_stack_trace_line_length", ob, 200);
+
+            if (maxCrashLogs && !this.maxBreadcrumbCount) {
+                this.maxBreadcrumbCount = maxCrashLogs;
+                log("'maxCrashLogs' is deprecated. Use 'maxBreadcrumbCount' instead!");
+            }
+            else if (!maxCrashLogs && !this.maxBreadcrumbCount) {
+                this.maxBreadcrumbCount = 100;
+            }
 
             if (this.storage === "cookie") {
                 lsSupport = false;
@@ -662,7 +670,7 @@
                 store("cly_id", this.device_id);
                 log("Changing id");
                 if (merge) {
-                    //no consent check here since 21.11
+                    //no consent check here since 21.11.0
                     toRequestQueue({ old_device_id: oldId });
                 }
                 else {
@@ -689,31 +697,38 @@
         this.add_event = function(event) {
             //initially no consent is given
             var respectiveConsent = false;
-            //to match the internal events and their respective required consents. Sets respectiveConsent to true if the consent is given
-            switch (event.key) {
-            case internalEventKeyEnums.NPS:
-                respectiveConsent = this.check_consent('feedback');
-                break;
-            case internalEventKeyEnums.SURVEY:
-                respectiveConsent = this.check_consent('feedback');
-                break;
-            case internalEventKeyEnums.STAR_RATING:
-                respectiveConsent = this.check_consent('star-rating');
-                break;
-            case internalEventKeyEnums.VIEW:
-                respectiveConsent = this.check_consent('view');
-                break;
-            case internalEventKeyEnums.ORIENTATION:
-                respectiveConsent = this.check_consent('users');
-                break;
-            case internalEventKeyEnums.PUSH_ACTION:
-                respectiveConsent = this.check_consent('push');
-                break;
-            case internalEventKeyEnums.ACTION:
-                respectiveConsent = this.check_consent('clicks') || this.check_consent('scroll');
-                break;
-            default:
-                respectiveConsent = false;
+            if (event.key in internalEventKeyEnums) {
+                //to match the internal events and their respective required consents. Sets respectiveConsent to true if the consent is given
+                switch (event.key) {
+                case internalEventKeyEnums.NPS:
+                    respectiveConsent = this.check_consent('feedback');
+                    break;
+                case internalEventKeyEnums.SURVEY:
+                    respectiveConsent = this.check_consent('feedback');
+                    break;
+                case internalEventKeyEnums.STAR_RATING:
+                    respectiveConsent = this.check_consent('star-rating');
+                    break;
+                case internalEventKeyEnums.VIEW:
+                    respectiveConsent = this.check_consent('view');
+                    break;
+                case internalEventKeyEnums.ORIENTATION:
+                    respectiveConsent = this.check_consent('users');
+                    break;
+                case internalEventKeyEnums.PUSH_ACTION:
+                    respectiveConsent = this.check_consent('push');
+                    break;
+                case internalEventKeyEnums.ACTION:
+                    respectiveConsent = this.check_consent('clicks') || this.check_consent('scroll');
+                    break;
+                default:
+                    respectiveConsent = false;
+                }
+            }
+            else {
+                if (this.check_consent('events')) {
+                    respectiveConsent = true;
+                }
             }
             //if consent is given adds event to the queue
             if (respectiveConsent) {
@@ -729,6 +744,7 @@
         function add_cly_events(event) {
             //ignore bots
             if (self.ignore_visitor) {
+                log('a');
                 return;
             }
 
@@ -738,6 +754,8 @@
             }
 
             if (!event.count) {
+                log('b');
+
                 event.count = 1;
             }
             //truncate event name and segmentation to internal limits
@@ -762,7 +780,7 @@
             //truncate event name to internal limits
             key = truncateSingleValue(key, self.maxKeyLength, "start_event", self.debug);
             if (timedEvents[key]) {
-                log("Timed event with key " + key + " already started");
+                log("Timed event with key [" + key + "] already started");
                 return;
             }
             timedEvents[key] = getTimestamp();
@@ -848,7 +866,7 @@
         * @param {Object=} user.custom - object with custom key value properties you want to save with user
         **/
         this.user_details = function(user) {
-            log("Adding user details: ", user);
+            log("Trying to add user details: ", user);
             if (this.check_consent(featureEnums.USERS)) {
                 //truncating user values and custom object key value pairs
                 user.name = truncateSingleValue(user.name, self.maxValueSize, "user_details", self.debug);
@@ -1148,15 +1166,9 @@
             if (this.check_consent(featureEnums.CRASHES)) {
                 //truncate description wrt internal limits
                 record = truncateSingleValue(record, self.maxValueSize, "add_log", self.debug);
-                var maxCrumbs = self.maxBreadcrumbCount; //default limit for breadcrumbs
-                //check if maxCrashLogs is used
-                if (self.maxBreadcrumbCount === 100 && maxCrashLogs !== 100) {
-                    maxCrumbs = maxCrashLogs;
-                    log("'maxCrashLogs' is deprecated. Use 'maxBreadcrumbCount' instead!");
-                }
-                while (crashLogs.length >= maxCrumbs) {
+                while (crashLogs.length >= self.maxBreadcrumbCount) {
                     crashLogs.shift();
-                    log("Reached maximum crashLogs number. Will erase the oldest one.");
+                    log("Reached maximum crashLogs size. Will erase the oldest one.");
                 }
                 crashLogs.push(record);
             }
@@ -3518,7 +3530,7 @@
                 newStr = str.substring(0, limit);
                 if (debugCondition && typeof console !== "undefined") {
                     // eslint-disable-next-line no-console
-                    console.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
+                    console.log(errorLog + ", Key: [" + str + "] is longer than accepted length. It will be truncated.");
                 }
             }
         }

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -172,6 +172,7 @@
             inactivityCounter = 0,
             sessionUpdate = getConfig("session_update", ob, 60),
             maxEventBatch = getConfig("max_events", ob, 100),
+            maxCrashLogs = getConfig("max_logs", ob, 100),
             useSessionCookie = getConfig("use_session_cookie", ob, true),
             sessionCookieTimeout = getConfig("session_cookie_timeout", ob, 30),
             readyToProcess = true,
@@ -740,8 +741,9 @@
             if (!event.count) {
                 event.count = 1;
             }
-            event.key = truncateSingleValue(event.key, this.maxKeyLength);
-            event.segmentation = truncateObject(event.segmentation, this.maxKeyLength, this.maxValueSize);
+            //truncate event name and segmentation to internal limits
+            event.key = truncateSingleValue(event.key, this.maxKeyLength, "add_cly_event");
+            event.segmentation = truncateObject(event.segmentation, this.maxKeyLength, this.maxValueSize, "add_cly_event");
             var props = ["key", "count", "sum", "dur", "segmentation"];
             var e = getProperties(event, props);
             e.timestamp = getMsTimestamp();
@@ -758,7 +760,8 @@
         * @param {string} key - event name that will be used as key property
         **/
         this.start_event = function(key) {
-            key = truncateSingleValue(key, this.maxKeyLength);
+            //truncate event name to internal limits
+            key = truncateSingleValue(key, this.maxKeyLength, "start_event");
             if (timedEvents[key]) {
                 log("Timed event with key " + key + " already started");
                 return;
@@ -835,16 +838,18 @@
         * @param {Object=} user.custom - object with custom key value properties you want to save with user
         **/
         this.user_details = function(user) {
-            user.name = truncateSingleValue(user.name, this.maxValueSize);
-            user.username = truncateSingleValue(user.username, this.maxValueSize);
-            user.email = truncateSingleValue(user.email, this.maxValueSize);
-            user.organization = truncateSingleValue(user.organization, this.maxValueSize);
-            user.phone = truncateSingleValue(user.phone, this.maxValueSize);
-            user.gender = truncateSingleValue(user.gender, this.maxValueSize);
-            user.byear = truncateSingleValue(user.byear, this.maxValueSize);
-            user.custom = truncateObject(user.custom, this.maxKeyLength, this.maxValueSize);
+            log("Adding user details: ", user);
             if (this.check_consent(featureEnums.USERS)) {
-                log("Adding user details: ", user);
+                //truncating user values and custom object key value pairs
+                user.name = truncateSingleValue(user.name, this.maxValueSize, "user_details");
+                user.username = truncateSingleValue(user.username, this.maxValueSize, "user_details");
+                user.email = truncateSingleValue(user.email, this.maxValueSize, "user_details");
+                user.organization = truncateSingleValue(user.organization, this.maxValueSize, "user_details");
+                user.phone = truncateSingleValue(user.phone, this.maxValueSize, "user_details");
+                user.picture = truncateSingleValue(user.picture, 4096, "user_details");
+                user.gender = truncateSingleValue(user.gender, this.maxValueSize, "user_details");
+                user.byear = truncateSingleValue(user.byear, this.maxValueSize, "user_details");
+                user.custom = truncateObject(user.custom, this.maxKeyLength, this.maxValueSize, "user_details");
                 var props = ["name", "username", "email", "organization", "phone", "picture", "gender", "byear", "custom"];
                 toRequestQueue({ user_details: JSON.stringify(getProperties(user, props)) });
             }
@@ -902,8 +907,9 @@
             * @param {string|number} value - value to store under provided property
             **/
             set: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate user's custom property value to internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData set");
+                value = truncateSingleValue(value, this.maxValueSize, "userData set");
                 customData[key] = value;
             },
             /**
@@ -921,8 +927,9 @@
             * @param {string|number} value - value to store under provided property
             **/
             set_once: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate user's custom property value to internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData set_once");
+                value = truncateSingleValue(value, this.maxValueSize, "userData set_once");
                 change_custom_property(key, value, "$setOnce");
             },
             /**
@@ -931,7 +938,8 @@
             * @param {string} key - name of the property to attach to user
             **/
             increment: function(key) {
-                key = truncateSingleValue(key, this.maxKeyLength);
+                //truncate property name wrt internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData increment");
                 change_custom_property(key, 1, "$inc");
             },
             /**
@@ -941,8 +949,9 @@
             * @param {number} value - value by which to increment server value
             **/
             increment_by: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate property name and value wrt internal limits 
+                key = truncateSingleValue(key, this.maxKeyLength, "userData increment_by");
+                value = truncateSingleValue(value, this.maxValueSize, "userData increment_by");
                 change_custom_property(key, value, "$inc");
             },
             /**
@@ -952,8 +961,9 @@
             * @param {number} value - value by which to multiply server value
             **/
             multiply: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate key value pair wrt internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData multiply");
+                value = truncateSingleValue(value, this.maxValueSize, "userData multiply");
                 change_custom_property(key, value, "$mul");
             },
             /**
@@ -963,8 +973,9 @@
             * @param {number} value - value which to compare to server's value and store maximal value of both provided
             **/
             max: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate key value pair wrt internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData max");
+                value = truncateSingleValue(value, this.maxValueSize, "userData max");
                 change_custom_property(key, value, "$max");
             },
             /**
@@ -974,8 +985,9 @@
             * @param {number} value - value which to compare to server's value and store minimal value of both provided
             **/
             min: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate key value pair wrt internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData min");
+                value = truncateSingleValue(value, this.maxValueSize, "userData min");
                 change_custom_property(key, value, "$min");
             },
             /**
@@ -985,8 +997,9 @@
             * @param {string|number} value - value which to add to array
             **/
             push: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate key value pair wrt internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData push");
+                value = truncateSingleValue(value, this.maxValueSize, "userData push");
                 change_custom_property(key, value, "$push");
             },
             /**
@@ -996,8 +1009,9 @@
             * @param {string|number} value - value which to add to array
             **/
             push_unique: function(key, value) {
-                key = truncateSingleValue(key, this.maxKeyLength);
-                value = truncateSingleValue(value, this.maxValueSize);
+                //truncate key value pair wrt internal limits
+                key = truncateSingleValue(key, this.maxKeyLength, "userData push_unique");
+                value = truncateSingleValue(value, this.maxValueSize, "userData push_unique");
                 change_custom_property(key, value, "$addToSet");
             },
             /**
@@ -1040,8 +1054,9 @@
                         return;
                     }
                 }
-                trace.name = truncateSingleValue(trace.name, this.maxKeyLength);
-                trace.app_metrics = truncateObject(trace.app_metrics, this.maxKeyLength, this.maxValueSize);
+                //truncate trace name and metrics wrt internal limits
+                trace.name = truncateSingleValue(trace.name, this.maxKeyLength, "report_trace");
+                trace.app_metrics = truncateObject(trace.app_metrics, this.maxKeyLength, this.maxValueSize, "report_trace");
                 var e = getProperties(trace, props);
                 e.timestamp = trace.stz;
                 var date = new Date();
@@ -1057,7 +1072,6 @@
         * @param {string=} segments - additional key value pairs you want to provide with error report, like versions of libraries used, etc.
         **/
         this.track_errors = function(segments) {
-            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
             Countly.i[this.app_key].tracking_crashes = true;
             if (!window.cly_crashes) {
                 window.cly_crashes = true;
@@ -1121,10 +1135,14 @@
         * @param {string} record - any text describing what user did
         **/
         this.add_log = function(record) {
-            record = truncateSingleValue(record, this.maxValueSize);
             if (this.check_consent(featureEnums.CRASHES)) {
-                if (crashLogs.length > this.maxBreadcrumbCount) {
+                //truncate description wrt internal limits
+                record = truncateSingleValue(record, this.maxValueSize, "add_log");
+                if (crashLogs.length > (this.maxBreadcrumbCount || maxCrashLogs || 100)) {
                     crashLogs.shift();
+                    if (!this.maxBreadcrumbCount && maxCrashLogs) {
+                        log("'maxCrashLogs' is deprecated. Use 'maxBreadcrumbCount' instead!");
+                    }
                 }
                 crashLogs.push(record);
             }
@@ -1331,8 +1349,9 @@
         **/
         this.track_pageview = function(page, ignoreList, viewSegments) {
             reportViewDuration();
-            page = truncateSingleValue(page, this.maxKeyLength);
-            viewSegments = truncateObject(viewSegments, this.maxKeyLength, this.maxValueSize);
+            //truncate page name and segmentation wrt internal limits
+            page = truncateSingleValue(page, this.maxKeyLength, "track_pageview");
+            viewSegments = truncateObject(viewSegments, this.maxKeyLength, this.maxValueSize, "track_pageview");
             //we got ignoreList first
             if (page && Array.isArray(page)) {
                 ignoreList = page;
@@ -1362,7 +1381,8 @@
                 "visit": 1,
                 "view": this.getViewUrl()
             };
-            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
+            //truncate new segment
+            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize, "track_pageview");
             if (this.track_domains) {
                 segments.domain = window.location.hostname;
             }
@@ -1453,7 +1473,8 @@
                                 "height": height,
                                 "view": self.getViewUrl()
                             };
-                            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
+                            //truncate new segment
+                            segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize, "processClick");
                             if (self.track_domains) {
                                 segments.domain = window.location.hostname;
                             }
@@ -1507,7 +1528,8 @@
                             "height": height,
                             "view": self.getViewUrl()
                         };
-                        segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
+                        //truncate new segment
+                        segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize, "processScrollView");
                         if (self.track_domains) {
                             segments.domain = window.location.hostname;
                         }
@@ -2324,7 +2346,6 @@
         this.recordError = function(err, nonfatal, segments) {
             if (this.check_consent(featureEnums.CRASHES) && err) {
                 segments = segments || crashSegments;
-                segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
                 var error = "";
                 if (typeof err === "object") {
                     if (typeof err.stack !== "undefined") {
@@ -2351,10 +2372,24 @@
                 else {
                     error = err + "";
                 }
-                var errorRegex = new RegExp("(?!$|\n)([^\n]{" + this.maxStackTraceLineLength + "}(?!\n))", "g");
-                error = error.replace(errorRegex, '$1\n');
-                if (error.split("\n").length > this.maxStackTraceLineLength) {
-                    error = error.split("\n").splice(0, this.maxStackTraceLinesPerThread).join("\n");
+                //truncate custom crash segment's key value pairs
+                segments = truncateObject(segments, this.maxKeyLength, this.maxValueSize);
+                //character limit check
+                if (error.length > (this.maxStackTraceLineLength * this.maxStackTraceLinesPerThread)) {
+                    //convert error into an array split from each newline 
+                    var splittedError = error.split("\n");
+                    //trim the array if it is too long
+                    if (splittedError.length > this.maxStackTraceLinesPerThread) {
+                        splittedError = splittedError.splice(0, this.maxStackTraceLinesPerThread);
+                    }
+                    //trim each line to a given limit
+                    for (var i = 0, len = splittedError.length; i < len - 1; i++) {
+                        if (splittedError[i].length > this.maxStackTraceLineLength) {
+                            splittedError[i] = splittedError[i].substring(0, this.maxStackTraceLineLength);
+                        }
+                    }
+                    //turn modified array back into error string
+                    error = splittedError.join("\n");
                 }
                 nonfatal = (nonfatal) ? true : false;
                 var metrics = getMetrics();
@@ -3104,8 +3139,8 @@
             get_event_target: get_event_target,
             add_event: add_event,
             getProperties: getProperties,
-            truncateSingleValue: truncateSingleValue,
             truncateObject: truncateObject,
+            truncateSingleValue: truncateSingleValue,
             stripTrailingSlash: stripTrailingSlash,
             prepareParams: prepareParams,
             sendXmlHttpRequest: sendXmlHttpRequest,
@@ -3169,6 +3204,7 @@
      * @param {number} [conf.inactivity_time=20] - after how many minutes user should be counted as inactive, if he did not perform any actions, as mouse move, scroll or keypress
      * @param {number} [conf.session_update=60] - how often in seconds should session be extended
      * @param {number} [conf.max_events=100] - maximum amount of events to send in one batch
+     * @deprecated {number} [conf.max_logs=100] - maximum amount of breadcrumbs to store for crash logs
      * @param {number} [conf.max_key_length=128] - maximum size of all string keys
      * @param {number} [conf.max_value_size=256] - maximum size of all values in our key-value pairs (Except "picture" field, that has a limit of 4096 chars)
      * @param {number} [conf.max_segmentation_values=30] - max amount of custom (dev provided) segmentation in one event
@@ -3373,44 +3409,84 @@
      * @param {Object} obj - original object to be truncated
      * @param {Number} keyLimit - limit for key length
      * @param {Number} valueLimit - limit for value length
+     * @param {string} errorLog - prefix for error log
      * @returns {Object} - the new truncated object
      */
-    function truncateObject(obj, keyLimit, valueLimit) {
+    function truncateObject(obj, keyLimit, valueLimit, errorLog) {
         var ob = {};
-        if (Object.keys(obj).length > this.maxSegmentationValues) {
-            var resizedObj = {};
-            for (var e in obj) {
-                resizedObj[e] = obj[e];
+        if (obj) {
+            if (Object.keys(obj).length > this.maxSegmentationValues) {
+                var resizedObj = {};
+                for (var e in obj) {
+                    resizedObj[e] = obj[e];
+                }
+                obj = resizedObj;
             }
-            obj = resizedObj;
-        }
-        for (var key in obj) {
-            var newKey = key;
-            var newValue = obj[key];
-            if (key.length > keyLimit) {
-                newKey = key.substring(0, keyLimit);
-                this.log("Key: " + key + " is longer than accepted length. It will be truncated.");
+            for (var key in obj) {
+                var newKey = key;
+                var newValue = obj[key];
+                if (typeof key === 'string') {
+                    if (key.length > keyLimit) {
+                        newKey = key.substring(0, keyLimit);
+                        this.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
+                    }
+                }
+                if (typeof obj[key] === 'string') {
+                    if (obj[key].length > valueLimit) {
+                        newValue = obj[key].substring(0, valueLimit);
+                        this.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
+                    }
+                }
+                if (typeof key === 'number') {
+                    newKey = newKey.toString();
+                    if (newKey.length > keyLimit) {
+                        newKey = parseInt(newKey.substring(0, keyLimit));
+                        this.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
+                    }
+                    else {
+                        newKey = parseInt(newKey);
+                    }
+                }
+                if (typeof obj[key] === 'number') {
+                    newValue = newValue.toString();
+                    if (newValue.length > valueLimit) {
+                        newValue = parseInt(newValue.substring(0, valueLimit));
+                        this.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
+                    }
+                    else {
+                        newValue = parseInt(newValue);
+                    }
+                }
+                ob[newKey] = newValue;
             }
-            if (obj[key].length > valueLimit && (typeof obj[key] === 'string' || typeof obj[key] === 'number')) {
-                newValue = obj[key].substring(0, valueLimit);
-                this.log("Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
-            }
-            ob[newKey] = newValue;
         }
         return ob;
     }
 
     /**
-     * Truncates a single string to a certain length
-     * @param {string|number} str - original string to be truncated
+     * Truncates a single value to a certain length
+     * @param {string|number} str - original value to be truncated
      * @param {Number} limit - limit length
-     * @returns {string|number} - the new truncated string
+     * @param {string} errorLog - prefix for error log
+     * @returns {string|number} - the new truncated value
      */
-    function truncateSingleValue(str, limit) {
+    function truncateSingleValue(str, limit, errorLog) {
         var newStr = str;
-        if (str.length > limit && (typeof str === 'string' || typeof str === 'number')) {
-            newStr = str.substring(0, limit);
-            this.log("Key: " + str + " is longer than accepted length. It will be truncated.");
+        if (typeof str === 'string') {
+            if (str.length > limit) {
+                newStr = str.substring(0, limit);
+                this.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
+            }
+        }
+        else if (typeof str === 'number') {
+            str = str.toString();
+            if (str.length > limit) {
+                newStr = parseInt(str.substring(0, limit));
+                this.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
+            }
+            else {
+                newStr = parseInt(str);
+            }
         }
         return newStr;
     }

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -742,9 +742,7 @@
                 event.count = 1;
             }
             //truncate event name and segmentation to internal limits
-            log(event.key + " <- to trunk");
             event.key = truncateSingleValue(event.key, self.maxKeyLength, "add_cly_event", self.debug);
-            log(event.key + " <- trunked?");
             event.segmentation = truncateObject(event.segmentation, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "add_cly_event", self.debug);
             var props = ["key", "count", "sum", "dur", "segmentation"];
             var e = getProperties(event, props);
@@ -3478,8 +3476,12 @@
         if (obj) {
             if (Object.keys(obj).length > segmentLimit) {
                 var resizedObj = {};
+                var i = 0;
                 for (var e in obj) {
-                    resizedObj[e] = obj[e];
+                    while (i < segmentLimit) {
+                        resizedObj[e] = obj[e];
+                        i++;
+                    }
                 }
                 obj = resizedObj;
             }

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -3611,13 +3611,13 @@
      */
     var get_event_target = function(event) {
         if (!event) {
-            return window.event.target;
+            return window.event.srcElement;
         }
         else if (typeof event.target !== "undefined") {
             return event.target;
         }
         else {
-            return event.target;
+            return event.srcElement;
         }
     };
 

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -3104,6 +3104,8 @@
             get_event_target: get_event_target,
             add_event: add_event,
             getProperties: getProperties,
+            truncateSingleValue: truncateSingleValue,
+            truncateObject: truncateObject,
             stripTrailingSlash: stripTrailingSlash,
             prepareParams: prepareParams,
             sendXmlHttpRequest: sendXmlHttpRequest,

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -183,7 +183,6 @@
             trackTime = true,
             startTime = getTimestamp(),
             lsSupport = true,
-            maxStackTraceThreadCount = 30,
             firstView = null;
 
         try {
@@ -761,7 +760,7 @@
         **/
         this.start_event = function(key) {
             //truncate event name to internal limits
-            key = truncateSingleValue(key, self.maxKeyLength, "start_event", this.debug);
+            key = truncateSingleValue(key, self.maxKeyLength, "start_event", self.debug);
             if (timedEvents[key]) {
                 log("Timed event with key " + key + " already started");
                 return;
@@ -852,15 +851,15 @@
             log("Adding user details: ", user);
             if (this.check_consent(featureEnums.USERS)) {
                 //truncating user values and custom object key value pairs
-                user.name = truncateSingleValue(user.name, self.maxValueSize, "user_details", this.debug);
-                user.username = truncateSingleValue(user.username, self.maxValueSize, "user_details", this.debug);
-                user.email = truncateSingleValue(user.email, self.maxValueSize, "user_details", this.debug);
-                user.organization = truncateSingleValue(user.organization, self.maxValueSize, "user_details", this.debug);
-                user.phone = truncateSingleValue(user.phone, self.maxValueSize, "user_details", this.debug);
-                user.picture = truncateSingleValue(user.picture, 4096, "user_details", this.debug);
-                user.gender = truncateSingleValue(user.gender, self.maxValueSize, "user_details", this.debug);
-                user.byear = truncateSingleValue(user.byear, self.maxValueSize, "user_details", this.debug);
-                user.custom = truncateObject(user.custom, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "user_details", this.debug);
+                user.name = truncateSingleValue(user.name, self.maxValueSize, "user_details", self.debug);
+                user.username = truncateSingleValue(user.username, self.maxValueSize, "user_details", self.debug);
+                user.email = truncateSingleValue(user.email, self.maxValueSize, "user_details", self.debug);
+                user.organization = truncateSingleValue(user.organization, self.maxValueSize, "user_details", self.debug);
+                user.phone = truncateSingleValue(user.phone, self.maxValueSize, "user_details", self.debug);
+                user.picture = truncateSingleValue(user.picture, 4096, "user_details", self.debug);
+                user.gender = truncateSingleValue(user.gender, self.maxValueSize, "user_details", self.debug);
+                user.byear = truncateSingleValue(user.byear, self.maxValueSize, "user_details", self.debug);
+                user.custom = truncateObject(user.custom, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "user_details", self.debug);
                 var props = ["name", "username", "email", "organization", "phone", "picture", "gender", "byear", "custom"];
                 toRequestQueue({ user_details: JSON.stringify(getProperties(user, props)) });
             }
@@ -919,8 +918,8 @@
             **/
             set: function(key, value) {
                 //truncate user's custom property value to internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData set", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData set", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData set", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData set", self.debug);
                 customData[key] = value;
             },
             /**
@@ -939,8 +938,8 @@
             **/
             set_once: function(key, value) {
                 //truncate user's custom property value to internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData set_once", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData set_once", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData set_once", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData set_once", self.debug);
                 change_custom_property(key, value, "$setOnce");
             },
             /**
@@ -950,7 +949,7 @@
             **/
             increment: function(key) {
                 //truncate property name wrt internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData increment", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData increment", self.debug);
                 change_custom_property(key, 1, "$inc");
             },
             /**
@@ -961,8 +960,8 @@
             **/
             increment_by: function(key, value) {
                 //truncate property name and value wrt internal limits 
-                key = truncateSingleValue(key, self.maxKeyLength, "userData increment_by", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData increment_by", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData increment_by", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData increment_by", self.debug);
                 change_custom_property(key, value, "$inc");
             },
             /**
@@ -973,8 +972,8 @@
             **/
             multiply: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData multiply", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData multiply", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData multiply", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData multiply", self.debug);
                 change_custom_property(key, value, "$mul");
             },
             /**
@@ -985,8 +984,8 @@
             **/
             max: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData max", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData max", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData max", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData max", self.debug);
                 change_custom_property(key, value, "$max");
             },
             /**
@@ -997,8 +996,8 @@
             **/
             min: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData min", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData min", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData min", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData min", self.debug);
                 change_custom_property(key, value, "$min");
             },
             /**
@@ -1009,8 +1008,8 @@
             **/
             push: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData push", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData push", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData push", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData push", self.debug);
                 change_custom_property(key, value, "$push");
             },
             /**
@@ -1021,8 +1020,8 @@
             **/
             push_unique: function(key, value) {
                 //truncate key value pair wrt internal limits
-                key = truncateSingleValue(key, self.maxKeyLength, "userData push_unique", this.debug);
-                value = truncateSingleValue(value, self.maxValueSize, "userData push_unique", this.debug);
+                key = truncateSingleValue(key, self.maxKeyLength, "userData push_unique", self.debug);
+                value = truncateSingleValue(value, self.maxValueSize, "userData push_unique", self.debug);
                 change_custom_property(key, value, "$addToSet");
             },
             /**
@@ -1066,8 +1065,8 @@
                     }
                 }
                 //truncate trace name and metrics wrt internal limits
-                trace.name = truncateSingleValue(trace.name, self.maxKeyLength, "report_trace", this.debug);
-                trace.app_metrics = truncateObject(trace.app_metrics, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "report_trace", this.debug);
+                trace.name = truncateSingleValue(trace.name, self.maxKeyLength, "report_trace", self.debug);
+                trace.app_metrics = truncateObject(trace.app_metrics, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "report_trace", self.debug);
                 var e = getProperties(trace, props);
                 e.timestamp = trace.stz;
                 var date = new Date();
@@ -1113,7 +1112,7 @@
                             var stack = [];
                             // eslint-disable-next-line no-caller
                             var f = arguments.callee.caller;
-                            while (f && stack.length < maxStackTraceThreadCount) {
+                            while (f) {
                                 stack.push(f.name);
                                 f = f.caller;
                             }
@@ -1148,12 +1147,16 @@
         this.add_log = function(record) {
             if (this.check_consent(featureEnums.CRASHES)) {
                 //truncate description wrt internal limits
-                record = truncateSingleValue(record, self.maxValueSize, "add_log", this.debug);
-                if (crashLogs.length > (self.maxBreadcrumbCount || maxCrashLogs || 100)) {
+                record = truncateSingleValue(record, self.maxValueSize, "add_log", self.debug);
+                var maxCrumbs = self.maxBreadcrumbCount; //default limit for breadcrumbs
+                //check if maxCrashLogs is used
+                if (self.maxBreadcrumbCount === 100 && maxCrashLogs !== 100) {
+                    maxCrumbs = maxCrashLogs;
+                    log("'maxCrashLogs' is deprecated. Use 'maxBreadcrumbCount' instead!");
+                }
+                while (crashLogs.length >= maxCrumbs) {
                     crashLogs.shift();
-                    if (!self.maxBreadcrumbCount && maxCrashLogs) {
-                        log("'maxCrashLogs' is deprecated. Use 'maxBreadcrumbCount' instead!");
-                    }
+                    log("Reached maximum crashLogs number. Will erase the oldest one.");
                 }
                 crashLogs.push(record);
             }
@@ -1361,8 +1364,8 @@
         this.track_pageview = function(page, ignoreList, viewSegments) {
             reportViewDuration();
             //truncate page name and segmentation wrt internal limits
-            page = truncateSingleValue(page, self.maxKeyLength, "track_pageview", this.debug);
-            viewSegments = truncateObject(viewSegments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "track_pageview", this.debug);
+            page = truncateSingleValue(page, self.maxKeyLength, "track_pageview", self.debug);
+            viewSegments = truncateObject(viewSegments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "track_pageview", self.debug);
             //we got ignoreList first
             if (page && Array.isArray(page)) {
                 ignoreList = page;
@@ -1393,7 +1396,7 @@
                 "view": this.getViewUrl()
             };
             //truncate new segment
-            segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "track_pageview", this.debug);
+            segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "track_pageview", self.debug);
             if (this.track_domains) {
                 segments.domain = window.location.hostname;
             }
@@ -1485,7 +1488,7 @@
                                 "view": self.getViewUrl()
                             };
                             //truncate new segment
-                            segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "processClick", this.debug);
+                            segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "processClick", self.debug);
                             if (self.track_domains) {
                                 segments.domain = window.location.hostname;
                             }
@@ -1540,7 +1543,7 @@
                             "view": self.getViewUrl()
                         };
                         //truncate new segment
-                        segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "processScrollView", this.debug);
+                        segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "processScrollView", self.debug);
                         if (self.track_domains) {
                             segments.domain = window.location.hostname;
                         }
@@ -2430,9 +2433,11 @@
                     error = err + "";
                 }
                 //truncate custom crash segment's key value pairs
-                segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "record_error", this.debug);
+                segments = truncateObject(segments, self.maxKeyLength, self.maxValueSize, self.maxSegmentationValues, "record_error", self.debug);
                 //character limit check
                 if (error.length > (self.maxStackTraceLineLength * self.maxStackTraceLinesPerThread)) {
+
+                    log("Error stack is too long will be truncated");
                     //convert error into an array split from each newline 
                     var splittedError = error.split("\n");
                     //trim the array if it is too long
@@ -2448,6 +2453,7 @@
                     //turn modified array back into error string
                     error = splittedError.join("\n");
                 }
+
                 nonfatal = (nonfatal) ? true : false;
                 var metrics = getMetrics();
                 var obj = { _resolution: metrics._resolution, _error: error, _app_version: metrics._app_version, _run: getTimestamp() - startTime };
@@ -3486,52 +3492,8 @@
                 obj = resizedObj;
             }
             for (var key in obj) {
-                var newKey = key;
-                var newValue = obj[key];
-                if (typeof key === 'string') {
-                    if (key.length > keyLimit) {
-                        newKey = key.substring(0, keyLimit);
-                        if (debugCondition && typeof console !== "undefined") {
-                            // eslint-disable-next-line no-console
-                            console.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
-                        }
-                    }
-                }
-                if (typeof obj[key] === 'string') {
-                    if (obj[key].length > valueLimit) {
-                        newValue = obj[key].substring(0, valueLimit);
-                        if (debugCondition && typeof console !== "undefined") {
-                            // eslint-disable-next-line no-console
-                            console.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
-                        }
-                    }
-                }
-                if (typeof key === 'number') {
-                    newKey = newKey.toString();
-                    if (newKey.length > keyLimit) {
-                        newKey = parseInt(newKey.substring(0, keyLimit));
-                        if (debugCondition && typeof console !== "undefined") {
-                            // eslint-disable-next-line no-console
-                            console.log(errorLog + ", Key: " + key + " is longer than accepted length. It will be truncated.");
-                        }
-                    }
-                    else {
-                        newKey = parseInt(newKey);
-                    }
-                }
-                if (typeof obj[key] === 'number') {
-                    newValue = newValue.toString();
-                    if (newValue.length > valueLimit) {
-                        newValue = parseInt(newValue.substring(0, valueLimit));
-                        if (debugCondition && typeof console !== "undefined") {
-                            // eslint-disable-next-line no-console
-                            console.log(errorLog + ", Value: " + obj[key] + " is longer than accepted length. It will be truncated.");
-                        }
-                    }
-                    else {
-                        newValue = parseInt(newValue);
-                    }
-                }
+                var newKey = truncateSingleValue(key, keyLimit, errorLog, debugCondition);
+                var newValue = truncateSingleValue(obj[key], valueLimit, errorLog, debugCondition);
                 ob[newKey] = newValue;
             }
         }
@@ -3548,6 +3510,9 @@
      */
     function truncateSingleValue(str, limit, errorLog, debugCondition) {
         var newStr = str;
+        if (typeof str === 'number') {
+            str = str.toString();
+        }
         if (typeof str === 'string') {
             if (str.length > limit) {
                 newStr = str.substring(0, limit);
@@ -3555,19 +3520,6 @@
                     // eslint-disable-next-line no-console
                     console.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
                 }
-            }
-        }
-        else if (typeof str === 'number') {
-            str = str.toString();
-            if (str.length > limit) {
-                newStr = parseInt(str.substring(0, limit));
-                if (debugCondition && typeof console !== "undefined") {
-                    // eslint-disable-next-line no-console
-                    console.log(errorLog + ", Key: " + str + " is longer than accepted length. It will be truncated.");
-                }
-            }
-            else {
-                newStr = parseInt(str);
             }
         }
         return newStr;

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -148,23 +148,24 @@
             trackTime = true,
             startTime = getTimestamp(),
             lsSupport = true,
+            maxStackTraceThreadCount = 30,
             firstView = null;
-
-        try {
-            localStorage.setItem("cly_testLocal", true);
-            //clean up test
-            localStorage.removeItem('cly_testLocal');
+            
+            try {
+                localStorage.setItem("cly_testLocal", true);
+                //clean up test
+                localStorage.removeItem('cly_testLocal');
         }
         catch (e) {
             lsSupport = false;
         }
-
+        
         //create object to store consents
         var consents = {};
         for (var it = 0; it < Countly.features.length; it++) {
             consents[Countly.features[it]] = {};
         }
-
+        
         this.initialize = function() {
             this.serialize = ob.serialize || Countly.serialize;
             this.deserialize = ob.deserialize || Countly.deserialize;
@@ -192,8 +193,14 @@
             this.track_domains = getConfig("track_domains", ob, true);
             this.storage = getConfig("storage", ob, "default");
             this.enableOrientationTracking = getConfig("enable_orientation_tracking", ob, true);
-
-
+            this.maxKeyLength = getConfig("max_key_length", ob, 128),
+            this.maxValueSize = getConfig("max_value_size", ob, 256),
+            this.maxSegmentationValues = getConfig("max_segmentation_values", ob, 30),
+            this.maxBreadcrumbCount = getConfig("max_breadcrumb_count", ob, 100),
+            this.maxStackTraceLinesPerThread = getConfig("max_stack_trace_lines_per_thread", ob, 30),
+            this.maxStackTraceLineLength = getConfig("max_stack_trace_line_length", ob, 200),
+            
+            
             if (this.storage === "cookie") {
                 lsSupport = false;
             }
@@ -657,6 +664,11 @@
                 return;
             }
 
+            if (event.key.length > maxKeyLength) {
+                log("add_cly_events, Event key: " + event.key + " is longer than accepted length");
+                return;
+            }
+
             if (!event.count) {
                 event.count = 1;
             }
@@ -677,6 +689,10 @@
         * @param {string} key - event name that will be used as key property
         **/
         this.start_event = function(key) {
+            if (key.length > maxKeyLength) {
+                log("start_event, Event key: " + key + " is longer than accepted length");
+                return;
+            }
             if (timedEvents[key]) {
                 log("Timed event with key " + key + " already started");
                 return;
@@ -933,7 +949,10 @@
                         return;
                     }
                 }
-
+                if (trace.name.length > maxKeyLength) {
+                    log("report_trace, Trace name: " + trace.name + " is longer than accepted length");
+                    return;
+                }
                 var e = getProperties(trace, props);
                 e.timestamp = trace.stz;
                 var date = new Date();
@@ -1221,6 +1240,10 @@
         **/
         this.track_pageview = function(page, ignoreList, viewSegments) {
             reportViewDuration();
+            if (page.length > maxKeyLength) {
+                log("track_pageview, Page name: " + page + " is longer than accepted length");
+                return;
+            }
             //we got ignoreList first
             if (page && Array.isArray(page)) {
                 ignoreList = page;
@@ -3050,6 +3073,12 @@
      * @param {number} [conf.session_update=60] - how often in seconds should session be extended
      * @param {number} [conf.max_events=100] - maximum amount of events to send in one batch
      * @param {number} [conf.max_logs=100] - maximum amount of breadcrumbs to store for crash logs
+     * @param {number} [conf.max_key_length=128] - maximum size of all string keys
+     * @param {number} [conf.max_value_size=256] - maximum size of all values in our key-value pairs (Except "picture" field, that has a limit of 4096 chars)
+     * @param {number} [conf.max_max_segmentation_values=30] - max amount of custom (dev provided) segmentation in one event
+     * @param {number} [conf.max_max_breadcrumb_count=100] - maximum amount of breadcrumbs that can be recorded before the oldest one is deleted
+     * @param {number} [conf.max_max_stack_trace_lines_per_thread=30] - maximum amount of stack trace lines would be recorded per thread
+     * @param {number} [conf.max_max_stack_trace_line_length=200] - maximum amount of characters are allowed per stack trace line. This limits also the crash message length
      * @param {array=} conf.ignore_referrers - array with referrers to ignore
      * @param {boolean} [conf.ignore_prefetch=true] - ignore prefetching and pre rendering from counting as real website visits
      * @param {boolean} [conf.force_post=false] - force using post method for all requests

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -697,38 +697,30 @@
         this.add_event = function(event) {
             //initially no consent is given
             var respectiveConsent = false;
-            if (event.key in internalEventKeyEnums) {
-                //to match the internal events and their respective required consents. Sets respectiveConsent to true if the consent is given
-                switch (event.key) {
-                case internalEventKeyEnums.NPS:
-                    respectiveConsent = this.check_consent('feedback');
-                    break;
-                case internalEventKeyEnums.SURVEY:
-                    respectiveConsent = this.check_consent('feedback');
-                    break;
-                case internalEventKeyEnums.STAR_RATING:
-                    respectiveConsent = this.check_consent('star-rating');
-                    break;
-                case internalEventKeyEnums.VIEW:
-                    respectiveConsent = this.check_consent('view');
-                    break;
-                case internalEventKeyEnums.ORIENTATION:
-                    respectiveConsent = this.check_consent('users');
-                    break;
-                case internalEventKeyEnums.PUSH_ACTION:
-                    respectiveConsent = this.check_consent('push');
-                    break;
-                case internalEventKeyEnums.ACTION:
-                    respectiveConsent = this.check_consent('clicks') || this.check_consent('scroll');
-                    break;
-                default:
-                    respectiveConsent = false;
-                }
-            }
-            else {
-                if (this.check_consent('events')) {
-                    respectiveConsent = true;
-                }
+            switch (event.key) {
+            case internalEventKeyEnums.NPS:
+                respectiveConsent = this.check_consent('feedback');
+                break;
+            case internalEventKeyEnums.SURVEY:
+                respectiveConsent = this.check_consent('feedback');
+                break;
+            case internalEventKeyEnums.STAR_RATING:
+                respectiveConsent = this.check_consent('star-rating');
+                break;
+            case internalEventKeyEnums.VIEW:
+                respectiveConsent = this.check_consent('view');
+                break;
+            case internalEventKeyEnums.ORIENTATION:
+                respectiveConsent = this.check_consent('users');
+                break;
+            case internalEventKeyEnums.PUSH_ACTION:
+                respectiveConsent = this.check_consent('push');
+                break;
+            case internalEventKeyEnums.ACTION:
+                respectiveConsent = this.check_consent('clicks') || this.check_consent('scroll');
+                break;
+            default:
+                respectiveConsent = this.check_consent('events');
             }
             //if consent is given adds event to the queue
             if (respectiveConsent) {
@@ -744,7 +736,6 @@
         function add_cly_events(event) {
             //ignore bots
             if (self.ignore_visitor) {
-                log('a');
                 return;
             }
 
@@ -754,8 +745,6 @@
             }
 
             if (!event.count) {
-                log('b');
-
                 event.count = 1;
             }
             //truncate event name and segmentation to internal limits


### PR DESCRIPTION
- Created 2 internal functions:

1. `truncateSingleValue` takes a single string or number and truncates it for a given limit, for example:
     `truncateSingleValue('abcd', 2)` will return `'ab'`
     and also it will create a log informing the user that the value is over the limit and will be truncated.
2. `truncateObject` takes an object and returns a new object with truncated key value pairs, for example:
     `truncateObject({'ab':'1234'}, 1, 2)` will return `{'a':'12'}`
     and also it will create a log informing the user that the key/value is over the limit and will be truncated.

- Used these functions to enforce internal limits where it seemed fit, especially segmentations and event creation.
- Limit values are set at init time, except the internal one (`maxStackTraceThreadCount`)
- Erased/Renamed `max_logs` with `max_breadcrumb_count`
- Added their respective comments except for `maxStackTraceThreadCount`
- Used regex to limit stack trace line limits.
- Performed unit tests on regex and functions individually. 
- Changed `srcElement` with `target` as it was deprecated
- Added changelog entry (was not sure about labeling, maybe potentially/minor breaking change)
