### PR TITLE
[Bug Fix] `clear_stored_id` flag, session cookie persistence fix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,15 +10,26 @@ on:
     branches: [master, staging]
 
 jobs:
-  build:
+  build-and-test:
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
-      - run: npm install --legacy-peer-deps
-      - run: npm run build --if-present
-      - run: npm test
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Build project (if present)
+        run: npm run build --if-present
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,25 +1,24 @@
 # This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Cypress tests
 
 on:
   push:
-    branches: [ master, staging ]
+    branches: [master, staging]
   pull_request:
-    branches: [ master, staging ]
+    branches: [master, staging]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: 14.x
-    - run: npm install
-    - run: npm run build --if-present
-    - run: npm test
+      - uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: "16.x"
-      - run: npm install
+      - run: npm install --legacy-peer-deps
       - run: npm run build --if-present
       - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 23.02.0
+- Fixed a bug where previous session cookie persisted even when the 'clear_stored_id' flag was set to true
+
 ## 22.06.5
 - SDK now adds userAgent string to each request to prevent proxy related issues
 - Added a method to cancel timed events manually

--- a/cypress/integration/consents.js
+++ b/cypress/integration/consents.js
@@ -10,7 +10,7 @@ function initMain(consent) {
         require_consent: consent,
         device_id: "György Ligeti",
         test_mode: true,
-        max_events: -1,
+        test_mode_eq: true,
         debug: true
     });
 }

--- a/cypress/integration/device_id.js
+++ b/cypress/integration/device_id.js
@@ -1,98 +1,14 @@
-/* eslint-disable cypress/no-unnecessary-waiting */
 /* eslint-disable require-jsdoc */
-/**
- * +--------------------------------------------------+------------------------------------+----------------------+
- * | SDK state at the end of the previous app session | Provided configuration during init | Action taken by SDK  |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |     Custom      |   SDK used a   |   Temp ID     |   Custom   |  Temporary  |   URL   |    Flag   |   flag   |
- * |   device ID     |   generated    |   mode was    | device ID  |  device ID  |         |    not    |          |
- * |    was set      |       ID       |   enabled     | provided   |  enabled    |         |    set    |   set    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      -     |      -      |    -    |    1      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      x     |      -      |    -    |    2      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      -     |      x      |    -    |    3      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      -     |      -      |    x    |    4      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      x     |      x      |    -    |    5      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      x     |      -      |    x    |    6      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      -     |      x      |    x    |    7      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      x     |      x      |    x    |    8      |    -     |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      -     |      -      |    -    |    17     |    33    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      x     |      -      |    -    |    18     |    34    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      -     |      x      |    -    |    19     |    35    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      -     |      -      |    x    |    20     |    36    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      x     |      x      |    -    |    21     |    37    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      x     |      -      |    x    |    22     |    38    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      -     |      x      |    x    |    23     |    39    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        x        |        -       |       -       |      x     |      x      |    x    |    24     |    40    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      -     |      -      |    -    |    25     |    41    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      x     |      -      |    -    |    26     |    42    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      -     |      x      |    -    |    27     |    43    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      -     |      -      |    x    |    28     |    44    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      x     |      x      |    -    |    29     |    45    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      x     |      -      |    x    |    30     |    46    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      -     |      x      |    x    |    31     |    47    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        -       |       x       |      x     |      x      |    x    |    32     |    48    |
- * +--------------------------------------------------+------------------------------------+----------------------+ 
- * |        -        |        x       |       -       |      -     |      -      |    -    |    49     |    57    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        x       |       -       |      x     |      -      |    -    |    50     |    58    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        x       |       -       |      -     |      x      |    -    |    51     |    59    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        x       |       -       |      -     |      -      |    x    |    52     |    60    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        x       |       -       |      x     |      x      |    -    |    53     |    61    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        x       |       -       |      x     |      -      |    x    |    54     |    62    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        x       |       -       |      -     |      x      |    x    |    55     |    63    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |        -        |        x       |       -       |      x     |      x      |    x    |    56     |    64    |
- * +--------------------------------------------------+------------------------------------+----------------------+ 
- * |                                        Change ID and offline mode tests                                      |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      -     |      -      |    -    |   9-10    |     -    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      x     |      -      |    -    |   11-12   |     -    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      -     |      x      |    -    |   13-14   |     -    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- * |                     First init                   |      -     |      -      |    x    |   15-16   |     -    |
- * +--------------------------------------------------+------------------------------------+----------------------+
- */
-
 var Countly = require("../../lib/countly");
 var hp = require("../support/helper");
 
-function initMain(deviceId, offline, searchQuery, clear) {
+function initMain(deviceId, offline, searchQuery, clear, rq, eq) {
     Countly.init({
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
         device_id: deviceId,
-        test_mode: true,
+        test_mode: rq,
+        test_mode_eq: eq,
         debug: true,
         clear_stored_id: clear,
         getSearchQuery: function() {
@@ -101,982 +17,289 @@ function initMain(deviceId, offline, searchQuery, clear) {
         offline_mode: offline
     });
 }
-function validateSdkGeneratedId(providedDeviceId) {
-    expect(providedDeviceId).to.exist;
-    expect(providedDeviceId.length).to.eq(36);
-    expect(Countly._internals.isUUID(providedDeviceId)).to.be.ok;
-}
-function validateInternalDeviceIdType(expectedType) {
-    expect(expectedType).to.eq(Countly._internals.getInternalDeviceIdType());
-}
-function checkRequestsForT(queue, expectedInternalType) {
-    for (var i = 0; i < queue.length; i++) {
-        expect(queue[i].t).to.exist;
-        expect(queue[i].t).to.eq(Countly._internals.getInternalDeviceIdType());
-        expect(queue[i].t).to.eq(expectedInternalType);
+
+const event = {
+    key: "buttonClick",
+    segmentation: {
+        id: "id"
     }
-}
-
-/**
- *device ID type:
-    *0 - device ID was set by the developer during init
-    *1 - device ID was auto generated by Countly
-    *2 - device ID was temporarily given by Countly
-    *3 - device ID was provided from location.search
- */
-var DeviceIdTypeInternalEnumsTest = {
-    DEVELOPER_SUPPLIED: 0,
-    SDK_GENERATED: 1,
-    TEMPORARY_ID: 2,
-    URL_PROVIDED: 3
 };
-describe("Device Id tests during first init", ()=>{
-    // sdk is initialized w/o custom device id, w/o offline mode, w/o utm device id
 
-    // we provide no device id information sdk should generate the id
-    it("1-SDK is initialized without custom device id, without offline mode, without utm device id", ()=>{
+// ====================================
+// Session cookie checks: We check situations where the session cookie is updated/erased
+// ====================================
+
+describe("Device ID init tests for session cookies", ()=>{
+    // situations that keeps the session cookie
+    it("Default behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            expect(Countly.get_device_id_type()).to.eq(Countly.DeviceIdType.SDK_GENERATED);
-            validateSdkGeneratedId(Countly.get_device_id());
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            initMain(undefined, false, undefined, false);
             Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false);
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.equal(cookie1, cookie2);
+                    });
+                });
             });
         });
     });
-    // we provide device id information sdk should use it
-    it("2-SDK is initialized with custom device id, without offline mode, without utm device id", ()=>{
+    it("Default behavior, change_id, merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain("gerwutztreimer", false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("gerwutztreimer");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            initMain(undefined, false, undefined, false);
             Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    // we provide no device id information sdk should generate the id
-    it("3-SDK is initialized without custom device id, with offline mode, without utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            });
-        });
-    });
-    it("4-SDK is initialized without custom device id, without offline mode, with utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("5-SDK is initialized with custom device id, with offline mode, without utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("customID", true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("customID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("6-SDK is initialized with custom device id, without offline mode, with utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("customID2", false, "?cly_device_id=someID");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("someID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("7-SDK is initialized without custom device id, with offline mode, with utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, true, "?cly_device_id=someID");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("someID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("8-SDK is initialized with custom device id, with offline mode, with utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("customID3", true, "?cly_device_id=someID2");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("someID2");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false);
+                    Countly.change_id("new_id", true);
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.equal(cookie1, cookie2);
+                    });
+                });
             });
         });
     });
 
-    // Here tests focus the device id change and offline mode
-    // first pair
-    it("9-SDK is initialized with no device id, not offline mode, not utm device id", ()=>{
+    // situations that changes the session cookie
+    it("Default behavior, change_id, no merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            validateSdkGeneratedId(Countly.get_device_id());
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.change_id("newID");
+            initMain(undefined, false, undefined, false);
             Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false);
+                    Countly.change_id("new_id");
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.notEqual(cookie1, cookie2);
+                    });
+                });
             });
         });
     });
-    it("10-SDK is initialized with no device id, not offline mode, not utm device id, but then offline", ()=>{
+    it("Clear storage behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            validateSdkGeneratedId(Countly.get_device_id());
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.enable_offline_mode();
-            Countly.change_id("newID");
+            initMain(undefined, false, undefined, false);
             Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, true); // clear stored id
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.notEqual(cookie1, cookie2);
+                    });
+                });
             });
         });
     });
-    // second pair
-    it("11-SDK is initialized with user defined device id, not offline mode, not utm device id", ()=>{
+});
+
+// ====================================
+// Event queue checks : We block the event queue processing to observe if internal event queue flushing works.
+// ====================================
+
+describe("Device ID init tests for event flushing", ()=>{
+    // situations where the event queue is kept (no flushing should happen)
+    it("Default behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain("userID", false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("userID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.change_id("newID");
-            Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            initMain(undefined, false, undefined, false, undefined, true);
+            Countly.add_event(event);
+            cy.fetch_local_event_queue().then((e1) => {
+                cy.log("event queue: " + e1);
+                const event1 = e1;
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, undefined, true);
+                    cy.fetch_local_event_queue().then((e2) => {
+                        cy.log("event queue: " + e2);
+                        const event2 = e2;
+                        assert.deepEqual(event1, event2);
+                    });
+                });
             });
         });
     });
-    it("12-SDK is initialized with user defined device id, not offline mode, not utm device id, but then offline", ()=>{
+    it("Default behavior, change_id, merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain("userID", false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("userID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.enable_offline_mode();
-            Countly.change_id("newID");
-            Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    // third pair
-    it("13-SDK is initialized with no device id, not offline mode, with utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.change_id("newID");
-            Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("14-SDK is initialized with no device id, not offline mode, with utm device id, but then offline", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.enable_offline_mode();
-            Countly.change_id("newID");
-            Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    // fourth pair
-    it("15-SDK is initialized with no device id, with offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.change_id("newID");
-            Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("16-SDK is initialized with no device id, with offline mode, no utm device id, but then offline", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.enable_offline_mode();
-            Countly.change_id("newID");
-            Countly.begin_session();
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("newID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            initMain(undefined, false, undefined, false, undefined, true);
+            Countly.add_event(event);
+            cy.fetch_local_event_queue().then((e1) => {
+                cy.log("event queue: " + e1);
+                const event1 = e1;
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, undefined, true);
+                    Countly.change_id("new_id", true);
+                    cy.fetch_local_event_queue().then((e2) => {
+                        cy.log("event queue: " + e2);
+                        const event2 = e2;
+                        assert.deepEqual(event1, event2);
+                    });
+                });
             });
         });
     });
 
-    // Auto generated or developer set device ID was present in the local storage before initialization
-    it("17-Stored ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+    // situations where the event queue is cleared/flushed. 
+    it("Default behavior, change_id, no merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("18-Stored ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("19-Stored ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("20-Stored ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("21-Stored ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("22-Stored ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("23-Stored ID precedence, SDK is initialized no device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("24-Stored ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("storedID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
+            initMain(undefined, false, undefined, false, undefined, true);
+            Countly.add_event(event);
+            cy.fetch_local_event_queue().then((e1) => {
+                cy.log("event queue: " + e1);
+                const event1 = e1;
 
-    // Temporary ID  was present in the local storage before initialization
-    it("25-Stored temp ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, undefined, true);
+                    Countly.change_id("new_id");
+                    cy.fetch_local_event_queue().then((e2) => {
+                        cy.log("event queue: " + e2);
+                        const event2 = e2;
+                        assert.notDeepEqual(event1, event2);
+                    });
+                });
             });
         });
     });
-    it("26-Stored temp ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+    it("Clear storage behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("counterID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("27-Stored temp ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            });
-        });
-    });
-    it("28-Stored temp ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("29-Stored temp ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, undefined);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("counterID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("30-Stored temp ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("31-Stored temp ID precedence, SDK is initialized with no device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("32-Stored temp ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, "?cly_device_id=abab");
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
+            initMain(undefined, false, undefined, false, undefined, true);
+            Countly.add_event(event);
+            cy.fetch_local_event_queue().then((e1) => {
+                cy.log("event queue: " + e1);
+                const event1 = e1;
 
-    // Same tests with clear device ID flag set to true
-    // Auto generated or developer set device ID was present in the local storage before initialization
-    it("33-Cleared ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            validateSdkGeneratedId(Countly.get_device_id());
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, true, undefined, true);
+                    cy.wait(1000).then(() => {
+                        cy.fetch_local_event_queue().then((e2) => {
+                            cy.log("event queue: " + e2);
+                            const event2 = e2;
+                            assert.notDeepEqual(event1, event2);
+                        });
+                    });
+                });
             });
         });
     });
-    it("34-Cleared ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("counterID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("35-Cleared ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            });
-        });
-    });
-    it("36-Cleared ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("37-Cleared ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("counterID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("38-Cleared ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("39-Cleared ID precedence, SDK is initialized with no device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("40-Cleared ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("storedID", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
+});
 
-    // Temporary ID  was present in the local storage before initialization
-    it("41-Cleared temp ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            validateSdkGeneratedId(Countly.get_device_id());
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("42-Cleared temp ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("counterID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("43-Cleared temp ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            });
-        });
-    });
-    it("44-Cleared temp ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, false, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("45-Cleared temp ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("counterID");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("46-Cleared temp ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", false, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("47-Cleared temp ID precedence, SDK is initialized with no device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain(undefined, true, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("48-Cleared temp ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain("[CLY]_temp_id", false, undefined);
-            Countly.halt();
-            initMain("counterID", true, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.eq("abab");
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
+// ====================================
+// Request queue checks: Situations where both event queue and request queue processes are stopped to observe if internal event queue flushing works
+// ====================================
 
-    // SDK generated ID was present prior the second init
-    it("49-Stored UUID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+describe("Device ID init tests for request state", ()=>{
+    it("Default behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, false, undefined);
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("50-Stored UUID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", false, undefined);
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("51-Stored UUID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, true, undefined);
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("52-Stored UUID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, false, "?cly_device_id=abab");
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("53-Stored UUID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", true, undefined);
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("54-Stored UUID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", false, "?cly_device_id=abab");
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("55-Stored UUID precedence, SDK is initialized no device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, true, "?cly_device_id=abab");
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
-    it("56-Stored UUID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", true, "?cly_device_id=abab");
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            });
-        });
-    });
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
 
-    // SDK generated ID was present prior the second init (same tests with flag set to true)
-    it("57-Stored UUID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, false, undefined, true);
-            validateSdkGeneratedId(Countly.get_device_id());
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, true, true);
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        assert.equal(r2.length, 0);
+                        assert.deepEqual(req1, req2);
+                    });
+                });
             });
         });
     });
-    it("58-Stored UUID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+    it("Default behavior, change_id, merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", false, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, true, true);
+                    Countly.change_id("new_id", true);
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        expect(r2[0].old_device_id).to.be.ok;
+                        assert.notDeepEqual(req1, req2);
+                    });
+                });
             });
         });
     });
-    it("59-Stored UUID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
+    it("Default behavior, change_id, no merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, true, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, true, true);
+                    Countly.change_id("new_id");
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        assert.equal(r2.length, 2);
+                        expect(r2[0].events).to.be.ok;
+                        expect(r2[1].begin_session).to.be.ok;
+                        assert.notDeepEqual(req1, req2);
+                    });
+                });
             });
         });
     });
-    it("60-Stored UUID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
+    it("Clear storage behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, false, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("61-Stored UUID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", true, undefined, true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
-            });
-        });
-    });
-    it("62-Stored UUID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", false, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("63-Stored UUID precedence, SDK is initialized no device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain(undefined, true, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            });
-        });
-    });
-    it("64-Stored UUID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
-        hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined);
-            var oldUUID = Countly.get_device_id();
-            Countly.halt();
-            initMain("counterID", true, "?cly_device_id=abab", true);
-            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
-            expect(Countly.get_device_id()).to.not.eq(oldUUID);
-            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
-            Countly.begin_session();
-            cy.fetch_local_request_queue().then((eq) => {
-                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, true, true, true);
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        assert.notDeepEqual(req1, req2);
+                    });
+                });
             });
         });
     });

--- a/cypress/integration/device_id_init_scenarios.js
+++ b/cypress/integration/device_id_init_scenarios.js
@@ -1,14 +1,98 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
 /* eslint-disable require-jsdoc */
+/**
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * | SDK state at the end of the previous app session | Provided configuration during init | Action taken by SDK  |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |     Custom      |   SDK used a   |   Temp ID     |   Custom   |  Temporary  |   URL   |    Flag   |   flag   |
+ * |   device ID     |   generated    |   mode was    | device ID  |  device ID  |         |    not    |          |
+ * |    was set      |       ID       |   enabled     | provided   |  enabled    |         |    set    |   set    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      -     |      -      |    -    |    1      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      x     |      -      |    -    |    2      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      -     |      x      |    -    |    3      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      -     |      -      |    x    |    4      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      x     |      x      |    -    |    5      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      x     |      -      |    x    |    6      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      -     |      x      |    x    |    7      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      x     |      x      |    x    |    8      |    -     |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      -     |      -      |    -    |    17     |    33    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      x     |      -      |    -    |    18     |    34    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      -     |      x      |    -    |    19     |    35    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      -     |      -      |    x    |    20     |    36    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      x     |      x      |    -    |    21     |    37    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      x     |      -      |    x    |    22     |    38    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      -     |      x      |    x    |    23     |    39    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        x        |        -       |       -       |      x     |      x      |    x    |    24     |    40    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      -     |      -      |    -    |    25     |    41    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      x     |      -      |    -    |    26     |    42    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      -     |      x      |    -    |    27     |    43    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      -     |      -      |    x    |    28     |    44    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      x     |      x      |    -    |    29     |    45    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      x     |      -      |    x    |    30     |    46    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      -     |      x      |    x    |    31     |    47    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        -       |       x       |      x     |      x      |    x    |    32     |    48    |
+ * +--------------------------------------------------+------------------------------------+----------------------+ 
+ * |        -        |        x       |       -       |      -     |      -      |    -    |    49     |    57    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        x       |       -       |      x     |      -      |    -    |    50     |    58    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        x       |       -       |      -     |      x      |    -    |    51     |    59    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        x       |       -       |      -     |      -      |    x    |    52     |    60    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        x       |       -       |      x     |      x      |    -    |    53     |    61    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        x       |       -       |      x     |      -      |    x    |    54     |    62    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        x       |       -       |      -     |      x      |    x    |    55     |    63    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |        -        |        x       |       -       |      x     |      x      |    x    |    56     |    64    |
+ * +--------------------------------------------------+------------------------------------+----------------------+ 
+ * |                                        Change ID and offline mode tests                                      |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      -     |      -      |    -    |   9-10    |     -    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      x     |      -      |    -    |   11-12   |     -    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      -     |      x      |    -    |   13-14   |     -    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ * |                     First init                   |      -     |      -      |    x    |   15-16   |     -    |
+ * +--------------------------------------------------+------------------------------------+----------------------+
+ */
+
 var Countly = require("../../lib/countly");
 var hp = require("../support/helper");
 
-function initMain(deviceId, offline, searchQuery, clear, rq, eq) {
+function initMain(deviceId, offline, searchQuery, clear) {
     Countly.init({
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
         device_id: deviceId,
-        test_mode: rq,
-        test_mode_eq: eq,
+        test_mode: true,
         debug: true,
         clear_stored_id: clear,
         getSearchQuery: function() {
@@ -17,289 +101,982 @@ function initMain(deviceId, offline, searchQuery, clear, rq, eq) {
         offline_mode: offline
     });
 }
-
-const event = {
-    key: "buttonClick",
-    segmentation: {
-        id: "id"
+function validateSdkGeneratedId(providedDeviceId) {
+    expect(providedDeviceId).to.exist;
+    expect(providedDeviceId.length).to.eq(36);
+    expect(Countly._internals.isUUID(providedDeviceId)).to.be.ok;
+}
+function validateInternalDeviceIdType(expectedType) {
+    expect(expectedType).to.eq(Countly._internals.getInternalDeviceIdType());
+}
+function checkRequestsForT(queue, expectedInternalType) {
+    for (var i = 0; i < queue.length; i++) {
+        expect(queue[i].t).to.exist;
+        expect(queue[i].t).to.eq(Countly._internals.getInternalDeviceIdType());
+        expect(queue[i].t).to.eq(expectedInternalType);
     }
+}
+
+/**
+ *device ID type:
+    *0 - device ID was set by the developer during init
+    *1 - device ID was auto generated by Countly
+    *2 - device ID was temporarily given by Countly
+    *3 - device ID was provided from location.search
+ */
+var DeviceIdTypeInternalEnumsTest = {
+    DEVELOPER_SUPPLIED: 0,
+    SDK_GENERATED: 1,
+    TEMPORARY_ID: 2,
+    URL_PROVIDED: 3
 };
+describe("Device Id tests during first init", ()=>{
+    // sdk is initialized w/o custom device id, w/o offline mode, w/o utm device id
 
-// ====================================
-// Session cookie checks: We check situations where the session cookie is updated/erased
-// ====================================
-
-describe("Device ID init tests for session cookies", ()=>{
-    // situations that keeps the session cookie
-    it("Default behavior", ()=>{
+    // we provide no device id information sdk should generate the id
+    it("1-SDK is initialized without custom device id, without offline mode, without utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false);
+            initMain(undefined, false, undefined);
+            expect(Countly.get_device_id_type()).to.eq(Countly.DeviceIdType.SDK_GENERATED);
+            validateSdkGeneratedId(Countly.get_device_id());
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
             Countly.begin_session();
-            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
-                cy.log("session cookie: " + c1);
-                const cookie1 = c1;
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false);
-                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
-                        cy.log("session cookie: " + c2);
-                        const cookie2 = c2;
-                        assert.equal(cookie1, cookie2);
-                    });
-                });
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
             });
         });
     });
-    it("Default behavior, change_id, merge", ()=>{
+    // we provide device id information sdk should use it
+    it("2-SDK is initialized with custom device id, without offline mode, without utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false);
+            initMain("gerwutztreimer", false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("gerwutztreimer");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             Countly.begin_session();
-            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
-                cy.log("session cookie: " + c1);
-                const cookie1 = c1;
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false);
-                    Countly.change_id("new_id", true);
-                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
-                        cy.log("session cookie: " + c2);
-                        const cookie2 = c2;
-                        assert.equal(cookie1, cookie2);
-                    });
-                });
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             });
         });
     });
-
-    // situations that changes the session cookie
-    it("Default behavior, change_id, no merge", ()=>{
+    // we provide no device id information sdk should generate the id
+    it("3-SDK is initialized without custom device id, with offline mode, without utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false);
+            initMain(undefined, true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
             Countly.begin_session();
-            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
-                cy.log("session cookie: " + c1);
-                const cookie1 = c1;
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false);
-                    Countly.change_id("new_id");
-                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
-                        cy.log("session cookie: " + c2);
-                        const cookie2 = c2;
-                        assert.notEqual(cookie1, cookie2);
-                    });
-                });
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
             });
         });
     });
-    it("Clear storage behavior", ()=>{
+    it("4-SDK is initialized without custom device id, without offline mode, with utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false);
+            initMain(undefined, false, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
             Countly.begin_session();
-            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
-                cy.log("session cookie: " + c1);
-                const cookie1 = c1;
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, true); // clear stored id
-                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
-                        cy.log("session cookie: " + c2);
-                        const cookie2 = c2;
-                        assert.notEqual(cookie1, cookie2);
-                    });
-                });
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
             });
         });
     });
-});
-
-// ====================================
-// Event queue checks : We block the event queue processing to observe if internal event queue flushing works.
-// ====================================
-
-describe("Device ID init tests for event flushing", ()=>{
-    // situations where the event queue is kept (no flushing should happen)
-    it("Default behavior", ()=>{
+    it("5-SDK is initialized with custom device id, with offline mode, without utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, undefined, true);
-            Countly.add_event(event);
-            cy.fetch_local_event_queue().then((e1) => {
-                cy.log("event queue: " + e1);
-                const event1 = e1;
-
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false, undefined, true);
-                    cy.fetch_local_event_queue().then((e2) => {
-                        cy.log("event queue: " + e2);
-                        const event2 = e2;
-                        assert.deepEqual(event1, event2);
-                    });
-                });
+            initMain("customID", true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("customID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             });
         });
     });
-    it("Default behavior, change_id, merge", ()=>{
+    it("6-SDK is initialized with custom device id, without offline mode, with utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, undefined, true);
-            Countly.add_event(event);
-            cy.fetch_local_event_queue().then((e1) => {
-                cy.log("event queue: " + e1);
-                const event1 = e1;
-
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false, undefined, true);
-                    Countly.change_id("new_id", true);
-                    cy.fetch_local_event_queue().then((e2) => {
-                        cy.log("event queue: " + e2);
-                        const event2 = e2;
-                        assert.deepEqual(event1, event2);
-                    });
-                });
+            initMain("customID2", false, "?cly_device_id=someID");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("someID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("7-SDK is initialized without custom device id, with offline mode, with utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, true, "?cly_device_id=someID");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("someID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("8-SDK is initialized with custom device id, with offline mode, with utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("customID3", true, "?cly_device_id=someID2");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("someID2");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
             });
         });
     });
 
-    // situations where the event queue is cleared/flushed. 
-    it("Default behavior, change_id, no merge", ()=>{
+    // Here tests focus the device id change and offline mode
+    // first pair
+    it("9-SDK is initialized with no device id, not offline mode, not utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, undefined, true);
-            Countly.add_event(event);
-            cy.fetch_local_event_queue().then((e1) => {
-                cy.log("event queue: " + e1);
-                const event1 = e1;
-
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false, undefined, true);
-                    Countly.change_id("new_id");
-                    cy.fetch_local_event_queue().then((e2) => {
-                        cy.log("event queue: " + e2);
-                        const event2 = e2;
-                        assert.notDeepEqual(event1, event2);
-                    });
-                });
+            initMain(undefined, false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            validateSdkGeneratedId(Countly.get_device_id());
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             });
         });
     });
-    it("Clear storage behavior", ()=>{
+    it("10-SDK is initialized with no device id, not offline mode, not utm device id, but then offline", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, undefined, true);
-            Countly.add_event(event);
-            cy.fetch_local_event_queue().then((e1) => {
-                cy.log("event queue: " + e1);
-                const event1 = e1;
-
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, true, undefined, true);
-                    cy.wait(1000).then(() => {
-                        cy.fetch_local_event_queue().then((e2) => {
-                            cy.log("event queue: " + e2);
-                            const event2 = e2;
-                            assert.notDeepEqual(event1, event2);
-                        });
-                    });
-                });
+            initMain(undefined, false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            validateSdkGeneratedId(Countly.get_device_id());
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.enable_offline_mode();
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             });
         });
     });
-});
-
-// ====================================
-// Request queue checks: Situations where both event queue and request queue processes are stopped to observe if internal event queue flushing works
-// ====================================
-
-describe("Device ID init tests for request state", ()=>{
-    it("Default behavior", ()=>{
+    // second pair
+    it("11-SDK is initialized with user defined device id, not offline mode, not utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, true, true);
-            Countly.add_event(event);
-            cy.fetch_local_request_queue().then((r1) => {
-                cy.log("request queue: " + r1);
-                const req1 = r1;
-                assert.equal(r1.length, 0);
-
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false, true, true);
-                    cy.fetch_local_request_queue().then((r2) => {
-                        cy.log("request queue: " + r2);
-                        const req2 = r2;
-                        assert.equal(r2.length, 0);
-                        assert.deepEqual(req1, req2);
-                    });
-                });
+            initMain("userID", false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("userID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             });
         });
     });
-    it("Default behavior, change_id, merge", ()=>{
+    it("12-SDK is initialized with user defined device id, not offline mode, not utm device id, but then offline", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, true, true);
-            Countly.add_event(event);
-            cy.fetch_local_request_queue().then((r1) => {
-                cy.log("request queue: " + r1);
-                const req1 = r1;
-                assert.equal(r1.length, 0);
-
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false, true, true);
-                    Countly.change_id("new_id", true);
-                    cy.fetch_local_request_queue().then((r2) => {
-                        cy.log("request queue: " + r2);
-                        const req2 = r2;
-                        expect(r2[0].old_device_id).to.be.ok;
-                        assert.notDeepEqual(req1, req2);
-                    });
-                });
+            initMain("userID", false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("userID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.enable_offline_mode();
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             });
         });
     });
-    it("Default behavior, change_id, no merge", ()=>{
+    // third pair
+    it("13-SDK is initialized with no device id, not offline mode, with utm device id", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, true, true);
-            Countly.add_event(event);
-            cy.fetch_local_request_queue().then((r1) => {
-                cy.log("request queue: " + r1);
-                const req1 = r1;
-                assert.equal(r1.length, 0);
-
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, false, true, true);
-                    Countly.change_id("new_id");
-                    cy.fetch_local_request_queue().then((r2) => {
-                        cy.log("request queue: " + r2);
-                        const req2 = r2;
-                        assert.equal(r2.length, 2);
-                        expect(r2[0].events).to.be.ok;
-                        expect(r2[1].begin_session).to.be.ok;
-                        assert.notDeepEqual(req1, req2);
-                    });
-                });
+            initMain(undefined, false, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
             });
         });
     });
-    it("Clear storage behavior", ()=>{
+    it("14-SDK is initialized with no device id, not offline mode, with utm device id, but then offline", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain(undefined, false, undefined, false, true, true);
-            Countly.add_event(event);
-            cy.fetch_local_request_queue().then((r1) => {
-                cy.log("request queue: " + r1);
-                const req1 = r1;
-                assert.equal(r1.length, 0);
+            initMain(undefined, false, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.enable_offline_mode();
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    // fourth pair
+    it("15-SDK is initialized with no device id, with offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("16-SDK is initialized with no device id, with offline mode, no utm device id, but then offline", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            Countly.enable_offline_mode();
+            Countly.change_id("newID");
+            Countly.begin_session();
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("newID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
 
-                Countly.halt();
-                cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, true, true, true);
-                    cy.fetch_local_request_queue().then((r2) => {
-                        cy.log("request queue: " + r2);
-                        const req2 = r2;
-                        assert.notDeepEqual(req1, req2);
-                    });
-                });
+    // Auto generated or developer set device ID was present in the local storage before initialization
+    it("17-Stored ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("18-Stored ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("19-Stored ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("20-Stored ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("21-Stored ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("22-Stored ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("23-Stored ID precedence, SDK is initialized no device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("24-Stored ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("storedID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+
+    // Temporary ID  was present in the local storage before initialization
+    it("25-Stored temp ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            });
+        });
+    });
+    it("26-Stored temp ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("counterID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("27-Stored temp ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            });
+        });
+    });
+    it("28-Stored temp ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("29-Stored temp ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, undefined);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("counterID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("30-Stored temp ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("31-Stored temp ID precedence, SDK is initialized with no device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("32-Stored temp ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, "?cly_device_id=abab");
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+
+    // Same tests with clear device ID flag set to true
+    // Auto generated or developer set device ID was present in the local storage before initialization
+    it("33-Cleared ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            validateSdkGeneratedId(Countly.get_device_id());
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("34-Cleared ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("counterID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("35-Cleared ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            });
+        });
+    });
+    it("36-Cleared ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("37-Cleared ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("counterID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("38-Cleared ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("39-Cleared ID precedence, SDK is initialized with no device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("40-Cleared ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("storedID", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+
+    // Temporary ID  was present in the local storage before initialization
+    it("41-Cleared temp ID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            validateSdkGeneratedId(Countly.get_device_id());
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("42-Cleared temp ID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("counterID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("43-Cleared temp ID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.eq("[CLY]_temp_id");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            });
+        });
+    });
+    it("44-Cleared temp ID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, false, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("45-Cleared temp ID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("counterID");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("46-Cleared temp ID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", false, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("47-Cleared temp ID precedence, SDK is initialized with no device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain(undefined, true, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("48-Cleared temp ID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain("[CLY]_temp_id", false, undefined);
+            Countly.halt();
+            initMain("counterID", true, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.eq("abab");
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+
+    // SDK generated ID was present prior the second init
+    it("49-Stored UUID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, false, undefined);
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("50-Stored UUID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", false, undefined);
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("51-Stored UUID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, true, undefined);
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("52-Stored UUID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, false, "?cly_device_id=abab");
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("53-Stored UUID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", true, undefined);
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("54-Stored UUID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", false, "?cly_device_id=abab");
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("55-Stored UUID precedence, SDK is initialized no device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, true, "?cly_device_id=abab");
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("56-Stored UUID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", true, "?cly_device_id=abab");
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+
+    // SDK generated ID was present prior the second init (same tests with flag set to true)
+    it("57-Stored UUID precedence, SDK is initialized with no device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, false, undefined, true);
+            validateSdkGeneratedId(Countly.get_device_id());
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.SDK_GENERATED);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.SDK_GENERATED);
+            });
+        });
+    });
+    it("58-Stored UUID precedence, SDK is initialized with device id, not offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", false, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("59-Stored UUID precedence, SDK is initialized with no device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, true, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.TEMPORARY_ID);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.TEMPORARY_ID);
+            });
+        });
+    });
+    it("60-Stored UUID precedence, SDK is initialized with no device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, false, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("61-Stored UUID precedence, SDK is initialized with device id, offline mode, no utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", true, undefined, true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.DEVELOPER_SUPPLIED);
+            });
+        });
+    });
+    it("62-Stored UUID precedence, SDK is initialized with device id, no offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", false, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("63-Stored UUID precedence, SDK is initialized no device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain(undefined, true, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            });
+        });
+    });
+    it("64-Stored UUID precedence, SDK is initialized with device id, offline mode, utm device id", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined);
+            var oldUUID = Countly.get_device_id();
+            Countly.halt();
+            initMain("counterID", true, "?cly_device_id=abab", true);
+            expect(Countly.get_device_id_type()).to.equal(Countly.DeviceIdType.DEVELOPER_SUPPLIED);
+            expect(Countly.get_device_id()).to.not.eq(oldUUID);
+            validateInternalDeviceIdType(DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
+            Countly.begin_session();
+            cy.fetch_local_request_queue().then((eq) => {
+                checkRequestsForT(eq, DeviceIdTypeInternalEnumsTest.URL_PROVIDED);
             });
         });
     });

--- a/cypress/integration/device_id_init_scenarios.js
+++ b/cypress/integration/device_id_init_scenarios.js
@@ -1,0 +1,102 @@
+/* eslint-disable require-jsdoc */
+var Countly = require("../../lib/countly");
+var hp = require("../support/helper");
+
+function initMain(deviceId, offline, searchQuery, clear) {
+    Countly.init({
+        app_key: "YOUR_APP_KEY",
+        url: "https://try.count.ly",
+        device_id: deviceId,
+        test_mode: true,
+        debug: true,
+        clear_stored_id: clear,
+        getSearchQuery: function() {
+            return searchQuery;
+        },
+        offline_mode: offline
+    });
+}
+
+describe("Device ID init tests", ()=>{
+    // situations that keeps the session cookie
+    it("Default behavior", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false);
+            Countly.begin_session();
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(3000).then(() => {
+                    initMain(undefined, false, undefined, false);
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.equal(cookie1, cookie2);
+                    });
+                });
+            });
+        });
+    });
+    it("Default behavior, change_id, merge", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false);
+            Countly.begin_session();
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(3000).then(() => {
+                    initMain(undefined, false, undefined, false);
+                    Countly.change_id("new_id", true);
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.equal(cookie1, cookie2);
+                    });
+                });
+            });
+        });
+    });
+
+    // situations that changes the session cookie
+    it("Default behavior, change_id, no merge", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false);
+            Countly.begin_session();
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(3000).then(() => {
+                    initMain(undefined, false, undefined, false);
+                    Countly.change_id("new_id");
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.notEqual(cookie1, cookie2);
+                    });
+                });
+            });
+        });
+    });
+    it("Clear storage behavior", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false);
+            Countly.begin_session();
+            cy.fetch_from_storage(undefined, "cly_session").then((c1) => {
+                cy.log("session cookie: " + c1);
+                const cookie1 = c1;
+                Countly.halt();
+                cy.wait(3000).then(() => {
+                    initMain(undefined, false, undefined, true); // clear stored id
+                    cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
+                        cy.log("session cookie: " + c2);
+                        const cookie2 = c2;
+                        assert.notEqual(cookie1, cookie2);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/cypress/integration/device_id_init_scenarios.js
+++ b/cypress/integration/device_id_init_scenarios.js
@@ -2,13 +2,13 @@
 var Countly = require("../../lib/countly");
 var hp = require("../support/helper");
 
-function initMain(deviceId, offline, searchQuery, clear) {
+function initMain(deviceId, offline, searchQuery, clear, rq, eq) {
     Countly.init({
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
         device_id: deviceId,
-        test_mode: true,
-        max_events: -1,
+        test_mode: rq,
+        test_mode_eq: eq,
         debug: true,
         clear_stored_id: clear,
         getSearchQuery: function() {
@@ -26,7 +26,7 @@ const event = {
 };
 
 // ====================================
-// Session cookie checks
+// Session cookie checks: We check situations where the session cookie is updated/erased
 // ====================================
 
 describe("Device ID init tests for session cookies", ()=>{
@@ -39,7 +39,7 @@ describe("Device ID init tests for session cookies", ()=>{
                 cy.log("session cookie: " + c1);
                 const cookie1 = c1;
                 Countly.halt();
-                cy.wait(3000).then(() => {
+                cy.wait(1000).then(() => {
                     initMain(undefined, false, undefined, false);
                     cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
                         cy.log("session cookie: " + c2);
@@ -58,7 +58,7 @@ describe("Device ID init tests for session cookies", ()=>{
                 cy.log("session cookie: " + c1);
                 const cookie1 = c1;
                 Countly.halt();
-                cy.wait(3000).then(() => {
+                cy.wait(1000).then(() => {
                     initMain(undefined, false, undefined, false);
                     Countly.change_id("new_id", true);
                     cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
@@ -80,7 +80,7 @@ describe("Device ID init tests for session cookies", ()=>{
                 cy.log("session cookie: " + c1);
                 const cookie1 = c1;
                 Countly.halt();
-                cy.wait(3000).then(() => {
+                cy.wait(1000).then(() => {
                     initMain(undefined, false, undefined, false);
                     Countly.change_id("new_id");
                     cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
@@ -100,7 +100,7 @@ describe("Device ID init tests for session cookies", ()=>{
                 cy.log("session cookie: " + c1);
                 const cookie1 = c1;
                 Countly.halt();
-                cy.wait(3000).then(() => {
+                cy.wait(1000).then(() => {
                     initMain(undefined, false, undefined, true); // clear stored id
                     cy.fetch_from_storage(undefined, "cly_session").then((c2) => {
                         cy.log("session cookie: " + c2);
@@ -114,13 +114,14 @@ describe("Device ID init tests for session cookies", ()=>{
 });
 
 // ====================================
-// Event queue checks
+// Event queue checks : We block the event queue processing to observe if internal event queue flushing works.
 // ====================================
 
-describe("Device ID init tests for session flushing", ()=>{
+describe("Device ID init tests for event flushing", ()=>{
+    // situations where the event queue is kept (no flushing should happen)
     it("Default behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain();
+            initMain(undefined, false, undefined, false, undefined, true);
             Countly.add_event(event);
             cy.fetch_local_event_queue().then((e1) => {
                 cy.log("event queue: " + e1);
@@ -128,7 +129,7 @@ describe("Device ID init tests for session flushing", ()=>{
 
                 Countly.halt();
                 cy.wait(1000).then(() => {
-                    initMain();
+                    initMain(undefined, false, undefined, false, undefined, true);
                     cy.fetch_local_event_queue().then((e2) => {
                         cy.log("event queue: " + e2);
                         const event2 = e2;
@@ -140,7 +141,7 @@ describe("Device ID init tests for session flushing", ()=>{
     });
     it("Default behavior, change_id, merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain();
+            initMain(undefined, false, undefined, false, undefined, true);
             Countly.add_event(event);
             cy.fetch_local_event_queue().then((e1) => {
                 cy.log("event queue: " + e1);
@@ -148,7 +149,7 @@ describe("Device ID init tests for session flushing", ()=>{
 
                 Countly.halt();
                 cy.wait(1000).then(() => {
-                    initMain();
+                    initMain(undefined, false, undefined, false, undefined, true);
                     Countly.change_id("new_id", true);
                     cy.fetch_local_event_queue().then((e2) => {
                         cy.log("event queue: " + e2);
@@ -159,9 +160,11 @@ describe("Device ID init tests for session flushing", ()=>{
             });
         });
     });
+
+    // situations where the event queue is cleared/flushed. 
     it("Default behavior, change_id, no merge", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain();
+            initMain(undefined, false, undefined, false, undefined, true);
             Countly.add_event(event);
             cy.fetch_local_event_queue().then((e1) => {
                 cy.log("event queue: " + e1);
@@ -169,7 +172,7 @@ describe("Device ID init tests for session flushing", ()=>{
 
                 Countly.halt();
                 cy.wait(1000).then(() => {
-                    initMain();
+                    initMain(undefined, false, undefined, false, undefined, true);
                     Countly.change_id("new_id");
                     cy.fetch_local_event_queue().then((e2) => {
                         cy.log("event queue: " + e2);
@@ -182,7 +185,7 @@ describe("Device ID init tests for session flushing", ()=>{
     });
     it("Clear storage behavior", ()=>{
         hp.haltAndClearStorage(() => {
-            initMain();
+            initMain(undefined, false, undefined, false, undefined, true);
             Countly.add_event(event);
             cy.fetch_local_event_queue().then((e1) => {
                 cy.log("event queue: " + e1);
@@ -190,13 +193,111 @@ describe("Device ID init tests for session flushing", ()=>{
 
                 Countly.halt();
                 cy.wait(1000).then(() => {
-                    initMain(undefined, false, undefined, true);
+                    initMain(undefined, false, undefined, true, undefined, true);
                     cy.wait(1000).then(() => {
                         cy.fetch_local_event_queue().then((e2) => {
                             cy.log("event queue: " + e2);
                             const event2 = e2;
                             assert.notDeepEqual(event1, event2);
                         });
+                    });
+                });
+            });
+        });
+    });
+});
+
+// ====================================
+// Request queue checks: Situations where both event queue and request queue processes are stopped to observe if internal event queue flushing works
+// ====================================
+
+describe("Device ID init tests for request state", ()=>{
+    it("Default behavior", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, true, true);
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        assert.equal(r2.length, 0);
+                        assert.deepEqual(req1, req2);
+                    });
+                });
+            });
+        });
+    });
+    it("Default behavior, change_id, merge", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, true, true);
+                    Countly.change_id("new_id", true);
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        expect(r2[0].old_device_id).to.be.ok;
+                        assert.notDeepEqual(req1, req2);
+                    });
+                });
+            });
+        });
+    });
+    it("Default behavior, change_id, no merge", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, false, true, true);
+                    Countly.change_id("new_id");
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        assert.equal(r2.length, 2);
+                        expect(r2[0].events).to.be.ok;
+                        expect(r2[1].begin_session).to.be.ok;
+                        assert.notDeepEqual(req1, req2);
+                    });
+                });
+            });
+        });
+    });
+    it("Clear storage behavior", ()=>{
+        hp.haltAndClearStorage(() => {
+            initMain(undefined, false, undefined, false, true, true);
+            Countly.add_event(event);
+            cy.fetch_local_request_queue().then((r1) => {
+                cy.log("request queue: " + r1);
+                const req1 = r1;
+                assert.equal(r1.length, 0);
+
+                Countly.halt();
+                cy.wait(1000).then(() => {
+                    initMain(undefined, false, undefined, true, true, true);
+                    cy.fetch_local_request_queue().then((r2) => {
+                        cy.log("request queue: " + r2);
+                        const req2 = r2;
+                        assert.notDeepEqual(req1, req2);
                     });
                 });
             });

--- a/cypress/integration/events.js
+++ b/cypress/integration/events.js
@@ -9,7 +9,7 @@ function initMain() {
         url: "https://try.count.ly",
         session_update: 3,
         test_mode: true,
-        max_events: -1,
+        test_mode_eq: true,
         debug: true
     });
 }

--- a/cypress/integration/internal_limits.js
+++ b/cypress/integration/internal_limits.js
@@ -16,7 +16,7 @@ function initMain() {
     Countly.init({
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
-        max_events: -1,
+        test_mode_eq: true,
         test_mode: true,
         debug: true,
         max_key_length: limits.key, // set maximum key length here

--- a/cypress/integration/manual_widget_reporting.js
+++ b/cypress/integration/manual_widget_reporting.js
@@ -59,7 +59,7 @@ function initMain() {
     Countly.init({
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
-        max_events: -1,
+        test_mode_eq: true,
         test_mode: true,
         debug: true
 

--- a/cypress/integration/reponse_validation.js
+++ b/cypress/integration/reponse_validation.js
@@ -12,7 +12,7 @@ function initMain() {
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
         test_mode: true,
-        max_events: -1,
+        test_mode_eq: true,
         debug: true
     });
 }

--- a/cypress/integration/storage.js
+++ b/cypress/integration/storage.js
@@ -6,7 +6,7 @@ function initMain(val) {
     Countly.init({
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
-        max_events: -1,
+        test_mode_eq: true,
         test_mode: true,
         debug: true,
         storage: val

--- a/cypress/integration/utm.js
+++ b/cypress/integration/utm.js
@@ -7,7 +7,7 @@ function initMulti(appKey, searchQuery, utmStuff) {
         app_key: appKey,
         url: "https://try.count.ly",
         test_mode: true,
-        max_events: -1,
+        test_mode_eq: true,
         utm: utmStuff,
         getSearchQuery: function() {
             return searchQuery;

--- a/cypress/integration/views.js
+++ b/cypress/integration/views.js
@@ -7,7 +7,7 @@ function initMain() {
     Countly.init({
         app_key: "YOUR_APP_KEY",
         url: "https://try.count.ly",
-        max_events: -1,
+        test_mode_eq: true,
         test_mode: true
     });
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -347,3 +347,15 @@ Cypress.Commands.add("fetch_local_event_queue", (appKey) => {
         });
     });
 });
+
+/**
+ * fetches values from local storage 
+ */
+Cypress.Commands.add("fetch_from_storage", (appKey, key) => {
+    cy.wait(hp.sWait).then(() => {
+        appKey = appKey || hp.appKey;
+        cy.getLocalStorage(`${hp.appKey}/${key}`).then((e) => {
+            return JSON.parse(e);
+        });
+    });
+});

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -259,6 +259,7 @@
             this.useExplicitRcApi = getConfig("use_explicit_rc_api", ob, false);
             this.debug = getConfig("debug", ob, false);
             this.test_mode = getConfig("test_mode", ob, false);
+            this.test_mode_eq = getConfig("test_mode_eq", ob, false);
             this.metrics = getConfig("metrics", ob, {});
             this.headers = getConfig("headers", ob, {});
             this.url = stripTrailingSlash(getConfig("url", ob, ""));
@@ -319,8 +320,22 @@
             remoteConfigs = getValueFromStorage("cly_remote_configs") || {};
 
             if (this.clearStoredId) {
+                // retrieve stored device ID and type from local storage and use it to flush existing events
+                if (getValueFromStorage("cly_id") && !tempIdModeWasEnabled) {
+                    this.device_id = getValueFromStorage("cly_id");
+                    log(logLevelEnums.DEBUG, "initialize, temporarily using the previous device ID to flush existing events");
+                    deviceIdType = getValueFromStorage("cly_id_type");
+                    if (!deviceIdType) {
+                        log(logLevelEnums.DEBUG, "initialize, No device ID type info from the previous session, falling back to DEVELOPER_SUPPLIED, for event flushing");
+                        deviceIdType = DeviceIdTypeInternalEnums.DEVELOPER_SUPPLIED;
+                    }
+                    sendEventsForced();
+                    // set them back to their initial values
+                    this.device_id = undefined;
+                    deviceIdType = DeviceIdTypeInternalEnums.SDK_GENERATED;
+                }
+                // then clear the storage so that a new device ID is set again later
                 log(logLevelEnums.INFO, "initialize, Clearing the device ID storage");
-                sendEventsForced();
                 localStorage.removeItem(this.app_key + "/cly_id");
                 localStorage.removeItem(this.app_key + "/cly_id_type");
                 localStorage.removeItem(this.app_key + "/cly_session");
@@ -417,7 +432,10 @@
             }
             // if test mode is enabled warn the user
             if (this.test_mode) {
-                log(logLevelEnums.WARNING, "initialize, test_mode:[" + this.test_mode + "], queues won't be processed");
+                log(logLevelEnums.WARNING, "initialize, test_mode:[" + this.test_mode + "], request queue won't be processed");
+            }
+            if (this.test_mode_eq) {
+                log(logLevelEnums.WARNING, "initialize, test_mode_eq:[" + this.test_mode_eq + "], event queue won't be processed");
             }
             // if test mode is enabled warn the user
             if (this.heatmapWhitelist) {
@@ -700,6 +718,7 @@
             self.ignore_prefetch = undefined;
             self.debug = undefined;
             self.test_mode = undefined;
+            self.test_mode_eq = undefined;
             self.metrics = undefined;
             self.headers = undefined;
             self.url = undefined;
@@ -3707,7 +3726,7 @@
             }
 
             // process event queue
-            if (eventQueue.length > 0) {
+            if (eventQueue.length > 0 && !self.test_mode_eq) {
                 if (eventQueue.length <= maxEventBatch) {
                     toRequestQueue({ events: JSON.stringify(eventQueue) });
                     eventQueue = [];

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -314,6 +314,10 @@
 
             migrate();
 
+            requestQueue = getValueFromStorage("cly_queue") || [];
+            eventQueue = getValueFromStorage("cly_event") || [];
+            remoteConfigs = getValueFromStorage("cly_remote_configs") || {};
+
             if (this.clearStoredId) {
                 log(logLevelEnums.INFO, "initialize, Clearing the device ID storage");
                 sendEventsForced();
@@ -322,9 +326,6 @@
                 localStorage.removeItem(this.app_key + "/cly_session");
             }
 
-            requestQueue = getValueFromStorage("cly_queue") || [];
-            eventQueue = getValueFromStorage("cly_event") || [];
-            remoteConfigs = getValueFromStorage("cly_remote_configs") || {};
 
             checkIgnore();
 
@@ -3418,6 +3419,7 @@
          */
         function sendEventsForced() {
             if (eventQueue.length > 0) {
+                log(logLevelEnums.DEBUG, "Flushing events");
                 toRequestQueue({ events: JSON.stringify(eventQueue) });
                 eventQueue = [];
                 setValueInStorage("cly_event", eventQueue);

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -476,8 +476,8 @@
                 log(logLevelEnums.DEBUG, "initialize, stored remote configs:[" + JSON.stringify(remoteConfigs) + "]");
             }
             // functions, if provided, would be printed as true without revealing their content
-            log(logLevelEnums.DEBUG, "initialize, 'getViewName' callback override provided:[" + !!this.getViewName + "]");
-            log(logLevelEnums.DEBUG, "initialize, 'getSearchQuery' callback override provided:[" + !!this.getSearchQuery + "]");
+            log(logLevelEnums.DEBUG, "initialize, 'getViewName' callback override provided:[" + (this.getViewName !== Countly.getViewName) + "]");
+            log(logLevelEnums.DEBUG, "initialize, 'getSearchQuery' callback override provided:[" + (this.getSearchQuery !== Countly.getSearchQuery) + "]");
 
             // limits are printed here if they were modified 
             if (this.maxKeyLength !== configurationDefaultValues.MAX_KEY_LENGTH) {

--- a/lib/countly.js
+++ b/lib/countly.js
@@ -316,8 +316,10 @@
 
             if (this.clearStoredId) {
                 log(logLevelEnums.INFO, "initialize, Clearing the device ID storage");
+                sendEventsForced();
                 localStorage.removeItem(this.app_key + "/cly_id");
                 localStorage.removeItem(this.app_key + "/cly_id_type");
+                localStorage.removeItem(this.app_key + "/cly_session");
             }
 
             requestQueue = getValueFromStorage("cly_queue") || [];
@@ -980,7 +982,7 @@
         * @param {bool} force - force begin session request even if session cookie is enabled
         */
         this.begin_session = function(noHeartBeat, force) {
-            log(logLevelEnums.INFO, "begin_session, Starting the session");
+            log(logLevelEnums.INFO, "begin_session, Starting the session. There was an ongoing session: [" + sessionStarted + "]");
             if (noHeartBeat) {
                 log(logLevelEnums.INFO, "begin_session, Heartbeats are disabled");
             }
@@ -1000,6 +1002,7 @@
                     sessionStarted = true;
                     autoExtend = !(noHeartBeat);
                     var expire = getValueFromStorage("cly_session");
+                    log(logLevelEnums.VERBOSE, "begin_session, Session state, forced: [" + force + "], useSessionCookie: [" + useSessionCookie + "], seconds to expire: [" + (expire - lastBeat) + "], expired: [" + (parseInt(expire) <= getTimestamp()) + "] ");
                     if (force || !useSessionCookie || !expire || parseInt(expire) <= getTimestamp()) {
                         log(logLevelEnums.INFO, "begin_session, Session started");
                         if (firstView === null) {
@@ -1039,7 +1042,7 @@
         * @param {bool} force - force end session request even if session cookie is enabled
         */
         this.end_session = function(sec, force) {
-            log(logLevelEnums.INFO, "end_session, Ending the current session");
+            log(logLevelEnums.INFO, "end_session, Ending the current session. There was an on going session:[" + sessionStarted + "]");
             if (this.check_consent(featureEnums.SESSIONS)) {
                 if (sessionStarted) {
                     sec = sec || getTimestamp() - lastBeat;


### PR DESCRIPTION
that file will validate the device ID changing flow

- during init
- with change id without merge
- with change id with merge

validating state of:

- session cookie
- event queue
- requests queue

[x] initial 'session cookie state' tests added.