### PR TITLE
Boomerang script removed

### DIFF
--- a/examples/example_apm.html
+++ b/examples/example_apm.html
@@ -4,10 +4,13 @@
   <!-- Page styling here -->
   <link rel='stylesheet' type='text/css' href='./style/style.css'>
 
-  <!--Countly script-->
+  <!--Countly script first-->
   <script type='text/javascript' src='../lib/countly.js'></script>
+
+  <!--BoomerangJS related scripts provided locally or over CDN here-->
   <script type='text/javascript' src='../plugin/boomerang/countly_boomerang.js'></script>
-  <script type='text/javascript' src="../plugin/boomerang/boomerang.min.js"></script>
+  <script type='text/javascript'
+    src="https://cdn.jsdelivr.net/npm/countly-sdk-web@latest/plugin/boomerang/countly_boomerang.js"></script>
   <script type='text/javascript'>
 
     //initializing countly with params

--- a/examples/mpa/index.html
+++ b/examples/mpa/index.html
@@ -131,14 +131,18 @@
       cly.src = '../../lib/countly.js';
       cly.onload = function () {
         // Boomerang related configuration
+        // Create boomerang script
         var boomerangScript = document.createElement('script');
         var countlyBoomerangScript = document.createElement('script');
+        // Set boomerang script attributes
         boomerangScript.async = true;
         countlyBoomerangScript.async = true;
 
-        boomerangScript.src = '../../plugin/boomerang/boomerang.min.js';
+        // Set boomerang script source either locally or from CDN
+        boomerangScript.src = 'https://cdn.jsdelivr.net/npm/countly-sdk-web@latest/plugin/boomerang/boomerang.min.js';
         countlyBoomerangScript.src = '../../plugin/boomerang/countly_boomerang.js';
 
+        // Append boomerang script to the head
         document.getElementsByTagName('head')[0].appendChild(boomerangScript);
         document.getElementsByTagName('head')[0].appendChild(countlyBoomerangScript);
         countlyBoomerangScript.onload = function () {

--- a/examples/mpa/index.html
+++ b/examples/mpa/index.html
@@ -11,8 +11,7 @@
 		<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'"></meta>
 	-->
   <!-- jquery-3 -->
-  <script src="https://code.jquery.com/jquery-3.5.1.min.js"
-    integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.1/jquery.min.js"></script>
   <!-- mobile view info -->
   <meta content="width=device-width, initial-scale=1, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
     name="viewport">
@@ -25,41 +24,6 @@
   <script src="helper_functions.js"></script>
   <!-- Async Countly init logic here -->
   <script type='text/javascript'>
-    // load BoomerangJS scripts after Countly is initiated this way 
-    syncScripts();
-    function syncScripts() {
-      // Here we should refer to the 'boomerang.min.js' and 'countly_boomerang.js' scripts' path in this order inside scripts array
-      // in your production implementation you would most likely have something like this:
-      // var scripts = ['../plugin/boomerang/boomerang.min.js', '../plugin/boomerang/countly_boomerang.js'];
-      //
-      // For ones with a keen eye, they might notice that these paths differ from the ones in the documentation, reason being that we would like to keep a single copy of these files
-      // in our repo so we directly refer to them from our plugin folder. 
-      //
-      // If you would like to use this example stand alone, you would need to copy those files and refer to their
-      // correct paths here. Like creating a folder and pasting them there and then referring to that folder. Folder name 
-      // does not matter as long as you provide them correctly in to the scripts array
-      var scripts = ['../../plugin/boomerang/boomerang.min.js', '../../plugin/boomerang/countly_boomerang.js'];
-      var i = 0;
-      function loopScriptList(scripts) {
-        recursiveScriptMaker(scripts[i], function () {
-          i++;
-          if (i < scripts.length) {
-            loopScriptList(scripts);
-          }
-        });
-      }
-      loopScriptList(scripts);
-    }
-    function recursiveScriptMaker(source, callback) {
-      var script = document.createElement('script');
-      script.onload = function () {
-        console.log('Successfully loaded the source: ' + source)
-        callback();
-      }
-      script.src = source;
-      document.getElementsByTagName('head')[0].appendChild(script);
-    }
-
     // Countly Related Settings
     var Countly = Countly || {};
     Countly.q = Countly.q || [];
@@ -166,7 +130,21 @@
       // provide the correct path according to your project structure
       cly.src = '../../lib/countly.js';
       cly.onload = function () {
-        Countly.init();
+        // Boomerang related configuration
+        var boomerangScript = document.createElement('script');
+        var countlyBoomerangScript = document.createElement('script');
+        boomerangScript.async = true;
+        countlyBoomerangScript.async = true;
+
+        boomerangScript.src = '../../plugin/boomerang/boomerang.min.js';
+        countlyBoomerangScript.src = '../../plugin/boomerang/countly_boomerang.js';
+
+        document.getElementsByTagName('head')[0].appendChild(boomerangScript);
+        document.getElementsByTagName('head')[0].appendChild(countlyBoomerangScript);
+        countlyBoomerangScript.onload = function () {
+          // init Countly only after boomerang is loaded
+          Countly.init();
+        };
       };
       var s = document.getElementsByTagName('script')[0];
       s.parentNode.insertBefore(cly, s);
@@ -191,15 +169,15 @@
     <h1>Web Demo App</h1>
     <p id="user-state" class="header-button"></p>
   </div>
-  
+
   <!-- Main content  -->
   <center>
     <!-- Center Image. Anything you want to show at the center.  -->
     <img src="../images/team_countly.jpg" id="wallpaper" />
 
     <!-- Welcome Text. With user name. -->
-    <h2 id="welcome-user"">No User is Signed In</h2>
-        <br />
+    <h2 id="welcome-user">No User is Signed In</h2>
+    <br />
 
     <!-- Button Group  -->
     <div id="buttons">
@@ -210,31 +188,26 @@
         <!-- Widget information section  -->
         <div id="widget-info">
           <div>
-            <label for="tags"">Tags</label>
-            <input id="widget-tag" value="" class="widget-info-lines"
-              type="text" name="tags" readonly />
+            <label for="tags">Tags</label>
+            <input id="widget-tag" value="" class="widget-info-lines" type="text" name="tags" readonly />
           </div>
           <div>
-            <label for="name"">Name</label>
-            <input id="widget-name" value="" class="widget-info-lines"
-              type="text" name="name" readonly />
+            <label for="name">Name</label>
+            <input id="widget-name" value="" class="widget-info-lines" type="text" name="name" readonly />
           </div>
           <div>
-            <label for="show-policy"">Show Policy</label>
-            <input id="widget-show-policy" value="" class="widget-info-lines"
-              type="text" name="show-policy" readonly />
+            <label for="show-policy">Show Policy</label>
+            <input id="widget-show-policy" value="" class="widget-info-lines" type="text" name="show-policy" readonly />
           </div>
           <div>
-            <label for="widget-id"">ID</label>
-            <input id="widget-id" value="" class="widget-info-lines"
-              type="text" name="widget-id" readonly />
+            <label for="widget-id">ID</label>
+            <input id="widget-id" value="" class="widget-info-lines" type="text" name="widget-id" readonly />
           </div>
         </div>
 
         <!-- Widget buttons  -->
         <div id="widget-buttons">
-          <button id="widget-info-icon" ><i class="fa fa-arrows-v"
-              aria-hidden="true"></i></button>
+          <button id="widget-info-icon"><i class="fa fa-arrows-v" aria-hidden="true"></i></button>
           <button id="nps" class="selective-button">
             Show NPS
           </button>

--- a/plugin/boomerang/countly_boomerang.js
+++ b/plugin/boomerang/countly_boomerang.js
@@ -7,8 +7,7 @@ Plugin being used - RT, AutoXHR, Continuity, NavigationTiming, ResourceTiming
 */
 (function cly_load_track_performance() {
     if (!window.Countly) {
-        // eslint-disable-next-line no-console
-        console.error("Countly is not defined. Boomerang will not be loaded. Check the load order of Countly and Boomerang scripts.");
+        // "Countly is not defined. Boomerang will not be loaded. Check the load order of Countly and Boomerang scripts.";
         return;
     }
     Countly = Countly || {}; // eslint-disable-line no-global-assign
@@ -18,10 +17,6 @@ Plugin being used - RT, AutoXHR, Continuity, NavigationTiming, ResourceTiming
             cly_load_track_performance();
             if (!Countly.track_performance && Countly.i) {
                 Countly.track_performance = Countly.i[Countly.app_key].track_performance;
-            }
-            else {
-                // eslint-disable-next-line no-console
-                console.warn("Countly instance is not defined.");
             }
         });
     }

--- a/plugin/boomerang/countly_boomerang.js
+++ b/plugin/boomerang/countly_boomerang.js
@@ -7,6 +7,7 @@ Plugin being used - RT, AutoXHR, Continuity, NavigationTiming, ResourceTiming
 */
 (function cly_load_track_performance() {
     if (!window.Countly) {
+        // eslint-disable-next-line no-console
         console.error("Countly is not defined. Boomerang will not be loaded. Check the load order of Countly and Boomerang scripts.");
         return;
     }
@@ -19,6 +20,7 @@ Plugin being used - RT, AutoXHR, Continuity, NavigationTiming, ResourceTiming
                 Countly.track_performance = Countly.i[Countly.app_key].track_performance;
             }
             else {
+                // eslint-disable-next-line no-console
                 console.warn("Countly instance is not defined.");
             }
         });

--- a/plugin/boomerang/countly_boomerang.js
+++ b/plugin/boomerang/countly_boomerang.js
@@ -18,6 +18,9 @@ Plugin being used - RT, AutoXHR, Continuity, NavigationTiming, ResourceTiming
             if (!Countly.track_performance && Countly.i) {
                 Countly.track_performance = Countly.i[Countly.app_key].track_performance;
             }
+            else {
+                console.warn("Countly instance is not defined.");
+            }
         });
     }
     /**

--- a/plugin/boomerang/countly_boomerang.js
+++ b/plugin/boomerang/countly_boomerang.js
@@ -6,12 +6,16 @@ Countly APM based on Boomerang JS
 Plugin being used - RT, AutoXHR, Continuity, NavigationTiming, ResourceTiming
 */
 (function cly_load_track_performance() {
+    if (!window.Countly) {
+        console.error("Countly is not defined. Boomerang will not be loaded. Check the load order of Countly and Boomerang scripts.");
+        return;
+    }
     Countly = Countly || {}; // eslint-disable-line no-global-assign
     Countly.onload = Countly.onload || [];
     if (typeof Countly.CountlyClass === "undefined") {
         return Countly.onload.push(function() {
             cly_load_track_performance();
-            if (!Countly.track_performance) {
+            if (!Countly.track_performance && Countly.i) {
                 Countly.track_performance = Countly.i[Countly.app_key].track_performance;
             }
         });


### PR DESCRIPTION
**In our example:**
Made it so that: Countly script loads > Boomerang script loads > Countly initializes 
Updated Jquery to latest
Removed the script responsible for loading boomerang and Countly
Fixed some typos making some UI unresponsive

**In countly_boomerang:**
Added an early return if Countly was not defined (script load order is wrong)
Added an extra check for if Countly instance is defined.

Did not used cdn for the scripts. Should we?